### PR TITLE
fix: tests for new Node.js parsers, unify jest configs

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.9)
 
 (using melange 0.1)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    rootDir: "./_build/default/",
-    testMatch: ["**/*_test.js"],
+  rootDir : "./_build/default/",
+  testMatch : [ "**/*_test.js" ],
+  testEnvironment : "node"
 };
-  

--- a/melange-json.opam
+++ b/melange-json.opam
@@ -12,7 +12,7 @@ license: ["LGPL-3.0-only" "MPL-2.0"]
 homepage: "https://github.com/melange-community/melange-json/"
 bug-reports: "https://github.com/melange-community/melange-json/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.9"}
   "ocaml" {>= "5.1"}
   "melange" {>= "3.0.0"}
   "melange-jest" {with-test}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
   "devDependencies": {
     "jest": "^26.5.2"
-  },
-  "jest": {
-    "testEnvironment": "node"
   }
 }

--- a/src/__tests__/Json_test.ml
+++ b/src/__tests__/Json_test.ml
@@ -17,6 +17,15 @@ let _ =
           try
             let (_ : Js.Json.t) = parseOrRaise "{" in
             fail "should throw"
-          with ParseError "Unexpected end of JSON input" -> pass));
+          with
+          | ParseError "Unexpected end of JSON input"
+          | ParseError (* Node.js v20 *)
+              "Expected property name or '}' in JSON at position 1"
+          | ParseError
+              (* Node.js v21 *)
+              "Expected property name or '}' in JSON at position 1 (line 1 \
+               column 2)"
+          ->
+            pass));
 
   test "stringify" (fun () -> expect @@ stringify Encode.null |> toEqual "null")


### PR DESCRIPTION
this makes `dune build @runtest` work for the various Node.js versions I highlighted in the tests