### PR TITLE
remove ocaml constraint

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,8 +27,7 @@
  (description
   "Provides encoders and decoders to convert JSON values into typed values. With the possibility to create custom encoders and decoders.")
  (depends
-  (ocaml
-   (>= "5.1"))
+  ocaml
   (melange
    (>= "3.0.0"))
   (melange-jest :with-test)

--- a/melange-json.opam
+++ b/melange-json.opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/melange-community/melange-json/"
 bug-reports: "https://github.com/melange-community/melange-json/issues"
 depends: [
   "dune" {>= "3.9"}
-  "ocaml" {>= "5.1"}
+  "ocaml"
   "melange" {>= "3.0.0"}
   "melange-jest" {with-test}
   "reason" {>= "3.10.0" & with-test}


### PR DESCRIPTION
Should be usable with 4.14 as well. Let's leave `melange` define which versions of `ocaml` are allowed.