### PR TITLE
docs: Update README.md to include required flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ The PPX is included in the `melange-json` package. To use it, just add the
 ```dune
 (library
  (modes melange)
- (preprocess (pps melange-json.ppx)))
+ (preprocess (pps melange-json.ppx))
+ (flags :standard -open Ppx_deriving_json_runtime.Primitives))
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -172,16 +172,18 @@ The PPX is included in the `melange-json` package. To use it, just add the
 ```dune
 (library
  (modes melange)
- (preprocess (pps melange-json.ppx))
- (flags :standard -open Ppx_deriving_json_runtime.Primitives))
+ (preprocess (pps melange-json.ppx)))
 ```
 
 ### Usage
 
-To generate JSON converters for a type, add the `[@@deriving json]` attribute to
-a type declaration:
+To generate JSON converters for a type,
+add the `[@@deriving json]` attribute to the type declaration,
+ensuring the converters for primitives like `int` and `string` are in scope if necessary:
 
 ```ocaml
+open Ppx_deriving_json_runtime.Primitives
+
 type t = {
   a: int;
   b: string;


### PR DESCRIPTION
In using the ppx, I had to follow the example from [ppx/test/ppx_deriving_json_js.e2e.t](ppx/test/ppx_deriving_json_js.e2e.t), which includes an extra compiler flag. Without this flag, the compiler error is:

```
12 |       jwt: string
                ^^^^^^
Error: Unbound value string_of_json
Hint: Did you mean string_of_bool?
```

I'm using melange 4 and melange-json 1.2.0:

```
$ opam list | grep melange
melange                 4.0.1-52    Toolchain to produce JS from Reason/OCaml
melange-json            1.2.0       Compositional JSON encode/decode library and PPX for Melange, with native compatibility
```