### PR TITLE
PPX: Add `yojson` as runtime dep for the native version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 - PPX: Add runtime for `result`
   ([#13](https://github.com/melange-community/melange-json/pull/13))
+- PPX: Add `yojson` as runtime dep for the native version
+  ([#15](https://github.com/melange-community/melange-json/pull/15))
 
 ## 1.3.0 (2024-08-28)
 

--- a/ppx/native/dune
+++ b/ppx/native/dune
@@ -7,7 +7,7 @@
   ppx_deriving_json_runtime
   ppx_deriving_json_native_test)
  (libraries ppxlib)
- (ppx_runtime_libraries melange-json-native.ppx-runtime)
+ (ppx_runtime_libraries melange-json-native.ppx-runtime yojson)
  (preprocess
   (pps ppxlib.metaquot))
  (kind ppx_deriver))

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -1,9 +1,10 @@
 
-  $ echo '(lang dune 3.11)' > dune-project
+  $ echo '(lang dune 3.11)
+  > (implicit_transitive_deps false)
+  > ' >> dune-project
   $ echo '
   > (executable 
   >   (name main)
-  >   (libraries yojson)
   >   (flags :standard -w -37-69 -open Ppx_deriving_json_runtime.Primitives)
   >   (preprocess (pps melange-json-native.ppx)))' > dune
 
@@ -15,57 +16,15 @@
   > ' >> main.ml
 
   $ dune build ./main.exe
+  File "example.ml", line 1, characters 0-33:
+  1 | type user = int [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Unbound module Yojson
+  [1]
 
   $ dune exec ./main.exe
-  JSON    DATA: 1
-  JSON REPRINT: 1
-  JSON    DATA: "OK"
-  JSON REPRINT: "OK"
-  JSON    DATA: "some"
-  JSON REPRINT: "some"
-  JSON    DATA: ["Ok", 1]
-  JSON REPRINT: ["Ok",1]
-  JSON    DATA: ["Error", "oops"]
-  JSON REPRINT: ["Error","oops"]
-  JSON    DATA: [42, "works"]
-  JSON REPRINT: [42,"works"]
-  JSON    DATA: {"name":"N","age":1}
-  JSON REPRINT: {"name":"N","age":1}
-  JSON    DATA: ["A"]
-  JSON REPRINT: ["A"]
-  JSON    DATA: ["B", 42]
-  JSON REPRINT: ["B",42]
-  JSON    DATA: ["C", {"name": "cname"}]
-  JSON REPRINT: ["C",{"name":"cname"}]
-  JSON    DATA: ["A"]
-  JSON REPRINT: ["A"]
-  JSON    DATA: ["B", 42]
-  JSON REPRINT: ["B",42]
-  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON    DATA: "A"
-  JSON REPRINT: "A"
-  JSON    DATA: "b_aliased"
-  JSON REPRINT: "b_aliased"
-  JSON    DATA: "b"
-  JSON REPRINT: "b"
-  JSON    DATA: "A_aliased"
-  JSON REPRINT: "A_aliased"
-  JSON    DATA: {"my_name":"N","my_age":1}
-  JSON REPRINT: {"my_name":"N","my_age":1}
-  JSON    DATA: {"my_name":"N"}
-  JSON REPRINT: {"my_name":"N","my_age":100}
-  JSON    DATA: {}
-  JSON REPRINT: {"k":null}
-  JSON    DATA: {"k":42}
-  JSON REPRINT: {"k":42}
-  JSON    DATA: ["A",1]
-  JSON REPRINT: ["A",1]
-  JSON    DATA: ["B","ok"]
-  JSON REPRINT: ["B","ok"]
-  JSON    DATA: {"a":1,"b":2}
-  JSON REPRINT: {"a":1}
-  JSON    DATA: ["A",{"a":1,"b":2}]
-  JSON REPRINT: ["A",{"a":1}]
+  File "example.ml", line 1, characters 0-33:
+  1 | type user = int [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Unbound module Yojson
+  [1]

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -16,15 +16,57 @@
   > ' >> main.ml
 
   $ dune build ./main.exe
-  File "example.ml", line 1, characters 0-33:
-  1 | type user = int [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Unbound module Yojson
-  [1]
 
   $ dune exec ./main.exe
-  File "example.ml", line 1, characters 0-33:
-  1 | type user = int [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Unbound module Yojson
-  [1]
+  JSON    DATA: 1
+  JSON REPRINT: 1
+  JSON    DATA: "OK"
+  JSON REPRINT: "OK"
+  JSON    DATA: "some"
+  JSON REPRINT: "some"
+  JSON    DATA: ["Ok", 1]
+  JSON REPRINT: ["Ok",1]
+  JSON    DATA: ["Error", "oops"]
+  JSON REPRINT: ["Error","oops"]
+  JSON    DATA: [42, "works"]
+  JSON REPRINT: [42,"works"]
+  JSON    DATA: {"name":"N","age":1}
+  JSON REPRINT: {"name":"N","age":1}
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["C", {"name": "cname"}]
+  JSON REPRINT: ["C",{"name":"cname"}]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: "A"
+  JSON REPRINT: "A"
+  JSON    DATA: "b_aliased"
+  JSON REPRINT: "b_aliased"
+  JSON    DATA: "b"
+  JSON REPRINT: "b"
+  JSON    DATA: "A_aliased"
+  JSON REPRINT: "A_aliased"
+  JSON    DATA: {"my_name":"N","my_age":1}
+  JSON REPRINT: {"my_name":"N","my_age":1}
+  JSON    DATA: {"my_name":"N"}
+  JSON REPRINT: {"my_name":"N","my_age":100}
+  JSON    DATA: {}
+  JSON REPRINT: {"k":null}
+  JSON    DATA: {"k":42}
+  JSON REPRINT: {"k":42}
+  JSON    DATA: ["A",1]
+  JSON REPRINT: ["A",1]
+  JSON    DATA: ["B","ok"]
+  JSON REPRINT: ["B","ok"]
+  JSON    DATA: {"a":1,"b":2}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: ["A",{"a":1,"b":2}]
+  JSON REPRINT: ["A",{"a":1}]


### PR DESCRIPTION
- The [first commit](https://github.com/melange-community/melange-json/commit/50d9adb28d7605874ea6c92c511953e325ca6037) shows the error that happened for users that don't add `yojson` as a dependency when using the lib (when `implicit_transitive_deps` is disabled)
- The [second commit](https://github.com/melange-community/melange-json/commit/5212cbb2c3f527f14b4884a11da3edb3bb606ff6) shows the error gone when adding `yojson` as runtime dep of the ppx