### PR TITLE
[PPX] Add `melange.ppx` as dep for the Melange version

### DIFF
--- a/ppx/browser/dune
+++ b/ppx/browser/dune
@@ -6,7 +6,7 @@
   \
   ppx_deriving_json_runtime
   ppx_deriving_json_js_test)
- (libraries ppxlib)
+ (libraries melange.ppx ppxlib)
  (ppx_runtime_libraries melange-json.ppx-runtime)
  (preprocess
   (pps ppxlib.metaquot))

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -26,65 +26,57 @@
   > ' >> main.ml
 
   $ dune build @js
-  File "example.ml", line 6, characters 0-60:
-  6 | type record = { name : string; age : int } [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 6, characters 0-60:
-  6 | type record = { name : string; age : int } [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 7, characters 0-132:
-  7 | type record_aliased = { name : string; [@json.key "my_name"] age : int; [@json.key "my_age"] [@json.default 100] } [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 7, characters 0-132:
-  7 | type record_aliased = { name : string; [@json.key "my_name"] age : int; [@json.key "my_age"] [@json.default 100] } [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 8, characters 0-70:
-  8 | type record_opt = { k : int option; [@json.option] } [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 9, characters 26-27:
-  9 | type sum = A | B of int | C of { name : string } [@@deriving json]
-                                ^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 17, characters 0-80:
-  17 | type allow_extra_fields = {a: int} [@@deriving json] [@@json.allow_extra_fields]
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 18, characters 27-28:
-  18 | type allow_extra_fields2 = A of {a: int} [@json.allow_extra_fields] [@@deriving json]
-                                  ^
-  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
-  
-  File "example.ml", line 6, characters 0-60:
-  6 | type record = { name : string; age : int } [@@deriving json]
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: ## is not a valid value identifier.
-  [1]
 
   $ node ./_build/default/output/main.js
-  node:internal/modules/cjs/loader:1137
-    throw err;
-    ^
-  
-  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output/main.js'
-      at Module._resolveFilename (node:internal/modules/cjs/loader:1134:15)
-      at Module._load (node:internal/modules/cjs/loader:975:27)
-      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
-      at node:internal/main/run_main_module:28:49 {
-    code: 'MODULE_NOT_FOUND',
-    requireStack: []
-  }
-  
-  Node.js v18.19.0
-  [1]
+  JSON    DATA: 1
+  JSON REPRINT: 1
+  JSON    DATA: "OK"
+  JSON REPRINT: "OK"
+  JSON    DATA: "some"
+  JSON REPRINT: "some"
+  JSON    DATA: ["Ok", 1]
+  JSON REPRINT: ["Ok",1]
+  JSON    DATA: ["Error", "oops"]
+  JSON REPRINT: ["Error","oops"]
+  JSON    DATA: [42, "works"]
+  JSON REPRINT: [42,"works"]
+  JSON    DATA: {"name":"N","age":1}
+  JSON REPRINT: {"name":"N","age":1}
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["C", {"name": "cname"}]
+  JSON REPRINT: ["C",{"name":"cname"}]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: "A"
+  JSON REPRINT: "A"
+  JSON    DATA: "b_aliased"
+  JSON REPRINT: "b_aliased"
+  JSON    DATA: "b"
+  JSON REPRINT: "b"
+  JSON    DATA: "A_aliased"
+  JSON REPRINT: "A_aliased"
+  JSON    DATA: {"my_name":"N","my_age":1}
+  JSON REPRINT: {"my_name":"N","my_age":1}
+  JSON    DATA: {"my_name":"N"}
+  JSON REPRINT: {"my_name":"N","my_age":100}
+  JSON    DATA: {}
+  JSON REPRINT: {"k":null}
+  JSON    DATA: {"k":42}
+  JSON REPRINT: {"k":42}
+  JSON    DATA: ["A",1]
+  JSON REPRINT: ["A",1]
+  JSON    DATA: ["B","ok"]
+  JSON REPRINT: ["B","ok"]
+  JSON    DATA: {"a":1,"b":2}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: ["A",{"a":1,"b":2}]
+  JSON REPRINT: ["A",{"a":1}]

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -1,6 +1,8 @@
 
-  $ echo '(lang dune 3.11) 
-  > (using melange 0.1)' > dune-project
+  $ echo '(lang dune 3.11)
+  > (using melange 0.1)
+  > (implicit_transitive_deps false)
+  > ' >> dune-project
 
   $ echo '
   > (library
@@ -8,7 +10,7 @@
   >  (modes melange)
   >  (modules example main)
   >  (flags :standard -w -37-69 -open Ppx_deriving_json_runtime.Primitives)
-  >  (preprocess (pps melange.ppx melange-json.ppx)))
+  >  (preprocess (pps melange-json.ppx)))
   > (melange.emit
   >  (alias js)
   >  (target output)
@@ -24,57 +26,65 @@
   > ' >> main.ml
 
   $ dune build @js
+  File "example.ml", line 6, characters 0-60:
+  6 | type record = { name : string; age : int } [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 6, characters 0-60:
+  6 | type record = { name : string; age : int } [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 7, characters 0-132:
+  7 | type record_aliased = { name : string; [@json.key "my_name"] age : int; [@json.key "my_age"] [@json.default 100] } [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 7, characters 0-132:
+  7 | type record_aliased = { name : string; [@json.key "my_name"] age : int; [@json.key "my_age"] [@json.default 100] } [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 8, characters 0-70:
+  8 | type record_opt = { k : int option; [@json.option] } [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 9, characters 26-27:
+  9 | type sum = A | B of int | C of { name : string } [@@deriving json]
+                                ^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 17, characters 0-80:
+  17 | type allow_extra_fields = {a: int} [@@deriving json] [@@json.allow_extra_fields]
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 18, characters 27-28:
+  18 | type allow_extra_fields2 = A of {a: int} [@json.allow_extra_fields] [@@deriving json]
+                                  ^
+  Alert unprocessed: `[@mel.*]' attributes found in external declaration. Did you forget to preprocess with `melange.ppx'?
+  
+  File "example.ml", line 6, characters 0-60:
+  6 | type record = { name : string; age : int } [@@deriving json]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: ## is not a valid value identifier.
+  [1]
 
   $ node ./_build/default/output/main.js
-  JSON    DATA: 1
-  JSON REPRINT: 1
-  JSON    DATA: "OK"
-  JSON REPRINT: "OK"
-  JSON    DATA: "some"
-  JSON REPRINT: "some"
-  JSON    DATA: ["Ok", 1]
-  JSON REPRINT: ["Ok",1]
-  JSON    DATA: ["Error", "oops"]
-  JSON REPRINT: ["Error","oops"]
-  JSON    DATA: [42, "works"]
-  JSON REPRINT: [42,"works"]
-  JSON    DATA: {"name":"N","age":1}
-  JSON REPRINT: {"name":"N","age":1}
-  JSON    DATA: ["A"]
-  JSON REPRINT: ["A"]
-  JSON    DATA: ["B", 42]
-  JSON REPRINT: ["B",42]
-  JSON    DATA: ["C", {"name": "cname"}]
-  JSON REPRINT: ["C",{"name":"cname"}]
-  JSON    DATA: ["A"]
-  JSON REPRINT: ["A"]
-  JSON    DATA: ["B", 42]
-  JSON REPRINT: ["B",42]
-  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
-  JSON    DATA: "A"
-  JSON REPRINT: "A"
-  JSON    DATA: "b_aliased"
-  JSON REPRINT: "b_aliased"
-  JSON    DATA: "b"
-  JSON REPRINT: "b"
-  JSON    DATA: "A_aliased"
-  JSON REPRINT: "A_aliased"
-  JSON    DATA: {"my_name":"N","my_age":1}
-  JSON REPRINT: {"my_name":"N","my_age":1}
-  JSON    DATA: {"my_name":"N"}
-  JSON REPRINT: {"my_name":"N","my_age":100}
-  JSON    DATA: {}
-  JSON REPRINT: {"k":null}
-  JSON    DATA: {"k":42}
-  JSON REPRINT: {"k":42}
-  JSON    DATA: ["A",1]
-  JSON REPRINT: ["A",1]
-  JSON    DATA: ["B","ok"]
-  JSON REPRINT: ["B","ok"]
-  JSON    DATA: {"a":1,"b":2}
-  JSON REPRINT: {"a":1}
-  JSON    DATA: ["A",{"a":1,"b":2}]
-  JSON REPRINT: ["A",{"a":1}]
+  node:internal/modules/cjs/loader:1137
+    throw err;
+    ^
+  
+  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output/main.js'
+      at Module._resolveFilename (node:internal/modules/cjs/loader:1134:15)
+      at Module._load (node:internal/modules/cjs/loader:975:27)
+      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
+      at node:internal/main/run_main_module:28:49 {
+    code: 'MODULE_NOT_FOUND',
+    requireStack: []
+  }
+  
+  Node.js v18.19.0
+  [1]

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -10,12 +10,18 @@
   
     [@@@ocaml.warning "-39-11-27"]
   
-    let rec user_of_json = (fun x -> int_of_json x : Js.Json.t -> user)
+    let rec user_of_json =
+      (fun x -> (int_of_json x [@ocaml.warning "-ignored-extra-argument"])
+        : Js.Json.t -> user)
+  
     let _ = user_of_json
   
     [@@@ocaml.warning "-39-11-27"]
   
-    let rec user_to_json = (fun x -> int_to_json x : user -> Js.Json.t)
+    let rec user_to_json =
+      (fun x -> (int_to_json x [@ocaml.warning "-ignored-extra-argument"])
+        : user -> Js.Json.t)
+  
     let _ = user_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
 
@@ -30,14 +36,14 @@
     [@@@ocaml.warning "-39-11-27"]
   
     let rec param_of_json a_of_json : Js.Json.t -> 'a param =
-     fun x -> a_of_json x
+     fun x -> (a_of_json x [@ocaml.warning "-ignored-extra-argument"])
   
     let _ = param_of_json
   
     [@@@ocaml.warning "-39-11-27"]
   
     let rec param_to_json a_to_json : 'a param -> Js.Json.t =
-     fun x -> a_to_json x
+     fun x -> (a_to_json x [@ocaml.warning "-ignored-extra-argument"])
   
     let _ = param_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
@@ -53,14 +59,22 @@
     [@@@ocaml.warning "-39-11-27"]
   
     let rec opt_of_json =
-      (fun x -> (option_of_json string_of_json) x : Js.Json.t -> opt)
+      (fun x ->
+         ((option_of_json string_of_json
+           [@ocaml.warning "-ignored-extra-argument"])
+            x [@ocaml.warning "-ignored-extra-argument"])
+        : Js.Json.t -> opt)
   
     let _ = opt_of_json
   
     [@@@ocaml.warning "-39-11-27"]
   
     let rec opt_to_json =
-      (fun x -> (option_to_json string_to_json) x : opt -> Js.Json.t)
+      (fun x ->
+         ((option_to_json string_to_json
+           [@ocaml.warning "-ignored-extra-argument"])
+            x [@ocaml.warning "-ignored-extra-argument"])
+        : opt -> Js.Json.t)
   
     let _ = opt_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
@@ -78,17 +92,32 @@
     let rec tuple_of_json =
       (fun x ->
          if
-           Stdlib.( && ) (Js.Array.isArray x)
+           Stdlib.( && )
+             (Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"])
              (Stdlib.( = )
-                (Js.Array.length (Obj.magic x : Js.Json.t array))
-                2)
+                (Js.Array.length
+                   ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+                     : Js.Json.t array)
+                 [@ocaml.warning "-ignored-extra-argument"])
+                2 [@ocaml.warning "-ignored-extra-argument"])
+           [@ocaml.warning "-ignored-extra-argument"]
          then
-           let es = (Obj.magic x : Js.Json.t array) in
-           ( int_of_json (Js.Array.unsafe_get es 0),
-             string_of_json (Js.Array.unsafe_get es 1) )
+           let es =
+             ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t array)
+           in
+           ( (int_of_json
+                (Js.Array.unsafe_get es 0
+                 [@ocaml.warning "-ignored-extra-argument"])
+              [@ocaml.warning "-ignored-extra-argument"]),
+             (string_of_json
+                (Js.Array.unsafe_get es 1
+                 [@ocaml.warning "-ignored-extra-argument"])
+              [@ocaml.warning "-ignored-extra-argument"]) )
          else
            Ppx_deriving_json_runtime.of_json_error
              "expected a JSON array of length 2"
+           [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> tuple)
   
     let _ = tuple_of_json
@@ -99,7 +128,13 @@
       (fun x ->
          match x with
          | x_0, x_1 ->
-             (Obj.magic [| int_to_json x_0; string_to_json x_1 |]
+             ((Obj.magic
+                 [|
+                   (int_to_json x_0
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                   (string_to_json x_1
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : tuple -> Js.Json.t)
   
@@ -121,32 +156,56 @@
          if
            Stdlib.not
              (Stdlib.( && )
-                (Stdlib.( = ) (Js.typeof x) "object")
+                (Stdlib.( = )
+                   (Js.typeof x [@ocaml.warning "-ignored-extra-argument"])
+                   "object" [@ocaml.warning "-ignored-extra-argument"])
                 (Stdlib.( && )
-                   (Stdlib.not (Js.Array.isArray x))
                    (Stdlib.not
-                      (Stdlib.( == ) (Obj.magic x : 'a Js.null) Js.null))))
+                      (Js.Array.isArray x
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                   (Stdlib.not
+                      (Stdlib.( == )
+                         ((Obj.magic x
+                           [@ocaml.warning "-ignored-extra-argument"])
+                           : 'a Js.null)
+                         Js.null [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 [@ocaml.warning "-ignored-extra-argument"])
+              [@ocaml.warning "-ignored-extra-argument"])
+           [@ocaml.warning "-ignored-extra-argument"]
          then
-           Ppx_deriving_json_runtime.of_json_error "expected a JSON object";
+           Ppx_deriving_json_runtime.of_json_error "expected a JSON object"
+           [@ocaml.warning "-ignored-extra-argument"];
          let fs =
-           (Obj.magic x
+           ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
              : < name : Js.Json.t Js.undefined
                ; age : Js.Json.t Js.undefined >
                Js.t)
          in
          {
            name =
-             (match Js.Undefined.toOption fs##name with
-             | Stdlib.Option.Some v -> string_of_json v
+             (match
+                Js.Undefined.toOption (Js.OO.unsafe_downgrade fs)#name
+                [@ocaml.warning "-ignored-extra-argument"]
+              with
+             | Stdlib.Option.Some v ->
+                 string_of_json v [@ocaml.warning "-ignored-extra-argument"]
              | Stdlib.Option.None ->
                  Ppx_deriving_json_runtime.of_json_error
-                   "missing field \"name\"");
+                   "missing field \"name\""
+                 [@ocaml.warning "-ignored-extra-argument"]);
            age =
-             (match Js.Undefined.toOption fs##age with
-             | Stdlib.Option.Some v -> int_of_json v
+             (match
+                Js.Undefined.toOption (Js.OO.unsafe_downgrade fs)#age
+                [@ocaml.warning "-ignored-extra-argument"]
+              with
+             | Stdlib.Option.Some v ->
+                 int_of_json v [@ocaml.warning "-ignored-extra-argument"]
              | Stdlib.Option.None ->
                  Ppx_deriving_json_runtime.of_json_error
-                   "missing field \"age\"");
+                   "missing field \"age\""
+                 [@ocaml.warning "-ignored-extra-argument"]);
          }
         : Js.Json.t -> record)
   
@@ -158,9 +217,23 @@
       (fun x ->
          match x with
          | { name = x_name; age = x_age } ->
-             (Obj.magic
-                [%mel.obj
-                  { name = string_to_json x_name; age = int_to_json x_age }]
+             ((Obj.magic
+                 (let module J = struct
+                    external unsafe_expr :
+                      name:'a0 -> age:'a1 -> < name : 'a0 ; age : 'a1 > Js.t
+                      = ""
+                        "\132\149\166\190\000\000\000\019\000\000\000\t\000\000\000\023\000\000\000\022\145\160\160A\144$name\160\160A\144#age@"
+                    [@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                  end in
+                 (J.unsafe_expr
+                    ~name:
+                      (string_to_json x_name
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    ~age:
+                      (int_to_json x_age
+                       [@ocaml.warning "-ignored-extra-argument"])
+                  [@ocaml.warning "-ignored-extra-argument"]))
+               [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : record -> Js.Json.t)
   
@@ -186,29 +259,52 @@
          if
            Stdlib.not
              (Stdlib.( && )
-                (Stdlib.( = ) (Js.typeof x) "object")
+                (Stdlib.( = )
+                   (Js.typeof x [@ocaml.warning "-ignored-extra-argument"])
+                   "object" [@ocaml.warning "-ignored-extra-argument"])
                 (Stdlib.( && )
-                   (Stdlib.not (Js.Array.isArray x))
                    (Stdlib.not
-                      (Stdlib.( == ) (Obj.magic x : 'a Js.null) Js.null))))
+                      (Js.Array.isArray x
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                   (Stdlib.not
+                      (Stdlib.( == )
+                         ((Obj.magic x
+                           [@ocaml.warning "-ignored-extra-argument"])
+                           : 'a Js.null)
+                         Js.null [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 [@ocaml.warning "-ignored-extra-argument"])
+              [@ocaml.warning "-ignored-extra-argument"])
+           [@ocaml.warning "-ignored-extra-argument"]
          then
-           Ppx_deriving_json_runtime.of_json_error "expected a JSON object";
+           Ppx_deriving_json_runtime.of_json_error "expected a JSON object"
+           [@ocaml.warning "-ignored-extra-argument"];
          let fs =
-           (Obj.magic x
+           ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
              : < my_name : Js.Json.t Js.undefined
                ; my_age : Js.Json.t Js.undefined >
                Js.t)
          in
          {
            name =
-             (match Js.Undefined.toOption fs##my_name with
-             | Stdlib.Option.Some v -> string_of_json v
+             (match
+                Js.Undefined.toOption (Js.OO.unsafe_downgrade fs)#my_name
+                [@ocaml.warning "-ignored-extra-argument"]
+              with
+             | Stdlib.Option.Some v ->
+                 string_of_json v [@ocaml.warning "-ignored-extra-argument"]
              | Stdlib.Option.None ->
                  Ppx_deriving_json_runtime.of_json_error
-                   "missing field \"my_name\"");
+                   "missing field \"my_name\""
+                 [@ocaml.warning "-ignored-extra-argument"]);
            age =
-             (match Js.Undefined.toOption fs##my_age with
-             | Stdlib.Option.Some v -> int_of_json v
+             (match
+                Js.Undefined.toOption (Js.OO.unsafe_downgrade fs)#my_age
+                [@ocaml.warning "-ignored-extra-argument"]
+              with
+             | Stdlib.Option.Some v ->
+                 int_of_json v [@ocaml.warning "-ignored-extra-argument"]
              | Stdlib.Option.None -> 100);
          }
         : Js.Json.t -> record_aliased)
@@ -221,12 +317,25 @@
       (fun x ->
          match x with
          | { name = x_name; age = x_age } ->
-             (Obj.magic
-                [%mel.obj
-                  {
-                    my_name = string_to_json x_name;
-                    my_age = int_to_json x_age;
-                  }]
+             ((Obj.magic
+                 (let module J = struct
+                    external unsafe_expr :
+                      my_name:'a0 ->
+                      my_age:'a1 ->
+                      < my_name : 'a0 ; my_age : 'a1 > Js.t
+                      = ""
+                        "\132\149\166\190\000\000\000\025\000\000\000\t\000\000\000\024\000\000\000\022\145\160\160A\144'my_name\160\160A\144&my_age@"
+                    [@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                  end in
+                 (J.unsafe_expr
+                    ~my_name:
+                      (string_to_json x_name
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    ~my_age:
+                      (int_to_json x_age
+                       [@ocaml.warning "-ignored-extra-argument"])
+                  [@ocaml.warning "-ignored-extra-argument"]))
+               [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : record_aliased -> Js.Json.t)
   
@@ -248,18 +357,41 @@
          if
            Stdlib.not
              (Stdlib.( && )
-                (Stdlib.( = ) (Js.typeof x) "object")
+                (Stdlib.( = )
+                   (Js.typeof x [@ocaml.warning "-ignored-extra-argument"])
+                   "object" [@ocaml.warning "-ignored-extra-argument"])
                 (Stdlib.( && )
-                   (Stdlib.not (Js.Array.isArray x))
                    (Stdlib.not
-                      (Stdlib.( == ) (Obj.magic x : 'a Js.null) Js.null))))
+                      (Js.Array.isArray x
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                   (Stdlib.not
+                      (Stdlib.( == )
+                         ((Obj.magic x
+                           [@ocaml.warning "-ignored-extra-argument"])
+                           : 'a Js.null)
+                         Js.null [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 [@ocaml.warning "-ignored-extra-argument"])
+              [@ocaml.warning "-ignored-extra-argument"])
+           [@ocaml.warning "-ignored-extra-argument"]
          then
-           Ppx_deriving_json_runtime.of_json_error "expected a JSON object";
-         let fs = (Obj.magic x : < k : Js.Json.t Js.undefined > Js.t) in
+           Ppx_deriving_json_runtime.of_json_error "expected a JSON object"
+           [@ocaml.warning "-ignored-extra-argument"];
+         let fs =
+           ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+             : < k : Js.Json.t Js.undefined > Js.t)
+         in
          {
            k =
-             (match Js.Undefined.toOption fs##k with
-             | Stdlib.Option.Some v -> (option_of_json int_of_json) v
+             (match
+                Js.Undefined.toOption (Js.OO.unsafe_downgrade fs)#k
+                [@ocaml.warning "-ignored-extra-argument"]
+              with
+             | Stdlib.Option.Some v ->
+                 (option_of_json int_of_json
+                  [@ocaml.warning "-ignored-extra-argument"])
+                   v [@ocaml.warning "-ignored-extra-argument"]
              | Stdlib.Option.None -> Stdlib.Option.None);
          }
         : Js.Json.t -> record_opt)
@@ -272,7 +404,20 @@
       (fun x ->
          match x with
          | { k = x_k } ->
-             (Obj.magic [%mel.obj { k = (option_to_json int_to_json) x_k }]
+             ((Obj.magic
+                 (let module J = struct
+                    external unsafe_expr : k:'a0 -> < k : 'a0 > Js.t
+                      = ""
+                        "\132\149\166\190\000\000\000\b\000\000\000\005\000\000\000\012\000\000\000\012\145\160\160A\144!k@"
+                    [@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                  end in
+                 (J.unsafe_expr
+                    ~k:
+                      ((option_to_json int_to_json
+                        [@ocaml.warning "-ignored-extra-argument"])
+                         x_k [@ocaml.warning "-ignored-extra-argument"])
+                  [@ocaml.warning "-ignored-extra-argument"]))
+               [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : record_opt -> Js.Json.t)
   
@@ -291,64 +436,138 @@
   
     let rec sum_of_json =
       (fun x ->
-         if Js.Array.isArray x then
-           let array = (Obj.magic x : Js.Json.t array) in
-           let len = Js.Array.length array in
-           if Stdlib.( > ) len 0 then
-             let tag = Js.Array.unsafe_get array 0 in
-             if Stdlib.( = ) (Js.typeof tag) "string" then
-               let tag = (Obj.magic tag : string) in
-               if Stdlib.( = ) tag "A" then (
-                 if Stdlib.( <> ) len 1 then
+         if Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"]
+         then
+           let array =
+             ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t array)
+           in
+           let len =
+             (Js.Array.length array
+              [@ocaml.warning "-ignored-extra-argument"])
+           in
+           if Stdlib.( > ) len 0 [@ocaml.warning "-ignored-extra-argument"]
+           then
+             let tag =
+               (Js.Array.unsafe_get array 0
+                [@ocaml.warning "-ignored-extra-argument"])
+             in
+             if
+               Stdlib.( = )
+                 (Js.typeof tag [@ocaml.warning "-ignored-extra-argument"])
+                 "string" [@ocaml.warning "-ignored-extra-argument"]
+             then
+               let tag =
+                 ((Obj.magic tag [@ocaml.warning "-ignored-extra-argument"])
+                   : string)
+               in
+               if
+                 Stdlib.( = ) tag "A"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 1
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 1";
+                     "expected a JSON array of length 1"
+                   [@ocaml.warning "-ignored-extra-argument"];
                  A)
-               else if Stdlib.( = ) tag "B" then (
-                 if Stdlib.( <> ) len 2 then
+               else if
+                 Stdlib.( = ) tag "B"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 2
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 2";
-                 B (int_of_json (Js.Array.unsafe_get array 1)))
-               else if Stdlib.( = ) tag "C" then (
-                 if Stdlib.( <> ) len 2 then
+                     "expected a JSON array of length 2"
+                   [@ocaml.warning "-ignored-extra-argument"];
+                 B
+                   (int_of_json
+                      (Js.Array.unsafe_get array 1
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"]))
+               else if
+                 Stdlib.( = ) tag "C"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 2
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 2";
-                 let fs = Js.Array.unsafe_get array 1 in
+                     "expected a JSON array of length 2"
+                   [@ocaml.warning "-ignored-extra-argument"];
+                 let fs =
+                   (Js.Array.unsafe_get array 1
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 in
                  if
                    Stdlib.not
                      (Stdlib.( && )
-                        (Stdlib.( = ) (Js.typeof fs) "object")
+                        (Stdlib.( = )
+                           (Js.typeof fs
+                            [@ocaml.warning "-ignored-extra-argument"])
+                           "object"
+                         [@ocaml.warning "-ignored-extra-argument"])
                         (Stdlib.( && )
-                           (Stdlib.not (Js.Array.isArray fs))
+                           (Stdlib.not
+                              (Js.Array.isArray fs
+                               [@ocaml.warning "-ignored-extra-argument"])
+                            [@ocaml.warning "-ignored-extra-argument"])
                            (Stdlib.not
                               (Stdlib.( == )
-                                 (Obj.magic fs : 'a Js.null)
-                                 Js.null))))
+                                 ((Obj.magic fs
+                                   [@ocaml.warning
+                                     "-ignored-extra-argument"])
+                                   : 'a Js.null)
+                                 Js.null
+                               [@ocaml.warning "-ignored-extra-argument"])
+                            [@ocaml.warning "-ignored-extra-argument"])
+                         [@ocaml.warning "-ignored-extra-argument"])
+                      [@ocaml.warning "-ignored-extra-argument"])
+                   [@ocaml.warning "-ignored-extra-argument"]
                  then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON object";
+                     "expected a JSON object"
+                   [@ocaml.warning "-ignored-extra-argument"];
                  let fs =
-                   (Obj.magic fs : < name : Js.Json.t Js.undefined > Js.t)
+                   ((Obj.magic fs [@ocaml.warning "-ignored-extra-argument"])
+                     : < name : Js.Json.t Js.undefined > Js.t)
                  in
                  C
                    {
                      name =
-                       (match Js.Undefined.toOption fs##name with
-                       | Stdlib.Option.Some v -> string_of_json v
+                       (match
+                          Js.Undefined.toOption
+                            (Js.OO.unsafe_downgrade fs)#name
+                          [@ocaml.warning "-ignored-extra-argument"]
+                        with
+                       | Stdlib.Option.Some v ->
+                           string_of_json v
+                           [@ocaml.warning "-ignored-extra-argument"]
                        | Stdlib.Option.None ->
                            Ppx_deriving_json_runtime.of_json_error
-                             "missing field \"name\"");
+                             "missing field \"name\""
+                           [@ocaml.warning "-ignored-extra-argument"]);
                    })
-               else Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+               else
+                 Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+                 [@ocaml.warning "-ignored-extra-argument"]
              else
                Ppx_deriving_json_runtime.of_json_error
                  "expected a non empty JSON array with element being a \
-                  string"
+                  string" [@ocaml.warning "-ignored-extra-argument"]
            else
              Ppx_deriving_json_runtime.of_json_error
                "expected a non empty JSON array"
+             [@ocaml.warning "-ignored-extra-argument"]
          else
            Ppx_deriving_json_runtime.of_json_error
              "expected a non empty JSON array"
+           [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> sum)
   
     let _ = sum_of_json
@@ -358,17 +577,43 @@
     let rec sum_to_json =
       (fun x ->
          match x with
-         | A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
+         | A ->
+             ((Obj.magic
+                 [|
+                   (string_to_json "A"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
          | B x_0 ->
-             (Obj.magic [| string_to_json "B"; int_to_json x_0 |]
+             ((Obj.magic
+                 [|
+                   (string_to_json "B"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                   (int_to_json x_0
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
          | C { name = x_name } ->
-             (Obj.magic
-                [|
-                  string_to_json "C";
-                  (Obj.magic [%mel.obj { name = string_to_json x_name }]
-                    : Js.Json.t);
-                |]
+             ((Obj.magic
+                 [|
+                   (string_to_json "C"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                   ((Obj.magic
+                       (let module J = struct
+                          external unsafe_expr :
+                            name:'a0 -> < name : 'a0 > Js.t
+                            = ""
+                              "\132\149\166\190\000\000\000\011\000\000\000\005\000\000\000\r\000\000\000\012\145\160\160A\144$name@"
+                          [@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                        end in
+                       (J.unsafe_expr
+                          ~name:
+                            (string_to_json x_name
+                             [@ocaml.warning "-ignored-extra-argument"])
+                        [@ocaml.warning "-ignored-extra-argument"]))
+                     [@ocaml.warning "-ignored-extra-argument"])
+                     : Js.Json.t);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : sum -> Js.Json.t)
   
@@ -387,15 +632,24 @@
   
     let rec other_of_json_poly =
       (fun x ->
-         let tag = Ppx_deriving_json_runtime.Primitives.string_of_json x in
-         if Stdlib.( = ) tag "C" then Some `C else None
+         let tag =
+           (Ppx_deriving_json_runtime.Primitives.string_of_json x
+            [@ocaml.warning "-ignored-extra-argument"])
+         in
+         if Stdlib.( = ) tag "C" [@ocaml.warning "-ignored-extra-argument"]
+         then Some `C
+         else None
         : Js.Json.t -> other option)
   
     and other_of_json =
       (fun x ->
-         match other_of_json_poly x with
+         match
+           other_of_json_poly x [@ocaml.warning "-ignored-extra-argument"]
+         with
          | Some x -> x
-         | None -> Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+         | None ->
+             Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+             [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> other)
   
     let _ = other_of_json_poly
@@ -405,7 +659,13 @@
   
     let rec other_to_json =
       (fun x ->
-         match x with `C -> (Obj.magic (string_to_json "C") : Js.Json.t)
+         match x with
+         | `C ->
+             ((Obj.magic
+                 (string_to_json "C"
+                  [@ocaml.warning "-ignored-extra-argument"])
+               [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
         : other -> Js.Json.t)
   
     let _ = other_to_json
@@ -420,44 +680,90 @@
   
     let rec poly_of_json_poly =
       (fun x ->
-         if Js.Array.isArray x then
-           let array = (Obj.magic x : Js.Json.t array) in
-           let len = Js.Array.length array in
-           if Stdlib.( > ) len 0 then
-             let tag = Js.Array.unsafe_get array 0 in
-             if Stdlib.( = ) (Js.typeof tag) "string" then
-               let tag = (Obj.magic tag : string) in
-               if Stdlib.( = ) tag "A" then (
-                 if Stdlib.( <> ) len 1 then
+         if Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"]
+         then
+           let array =
+             ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t array)
+           in
+           let len =
+             (Js.Array.length array
+              [@ocaml.warning "-ignored-extra-argument"])
+           in
+           if Stdlib.( > ) len 0 [@ocaml.warning "-ignored-extra-argument"]
+           then
+             let tag =
+               (Js.Array.unsafe_get array 0
+                [@ocaml.warning "-ignored-extra-argument"])
+             in
+             if
+               Stdlib.( = )
+                 (Js.typeof tag [@ocaml.warning "-ignored-extra-argument"])
+                 "string" [@ocaml.warning "-ignored-extra-argument"]
+             then
+               let tag =
+                 ((Obj.magic tag [@ocaml.warning "-ignored-extra-argument"])
+                   : string)
+               in
+               if
+                 Stdlib.( = ) tag "A"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 1
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 1";
+                     "expected a JSON array of length 1"
+                   [@ocaml.warning "-ignored-extra-argument"];
                  Some `A)
-               else if Stdlib.( = ) tag "B" then (
-                 if Stdlib.( <> ) len 2 then
+               else if
+                 Stdlib.( = ) tag "B"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 2
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 2";
-                 Some (`B (int_of_json (Js.Array.unsafe_get array 1))))
+                     "expected a JSON array of length 2"
+                   [@ocaml.warning "-ignored-extra-argument"];
+                 Some
+                   (`B
+                     (int_of_json
+                        (Js.Array.unsafe_get array 1
+                         [@ocaml.warning "-ignored-extra-argument"])
+                      [@ocaml.warning "-ignored-extra-argument"])))
                else
-                 match other_of_json_poly x with
+                 match
+                   other_of_json_poly x
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 with
                  | Some x -> (Some x :> [ `A | `B of int | other ] option)
                  | None -> None
              else
                Ppx_deriving_json_runtime.of_json_error
                  "expected a non empty JSON array with element being a \
-                  string"
+                  string" [@ocaml.warning "-ignored-extra-argument"]
            else
              Ppx_deriving_json_runtime.of_json_error
                "expected a non empty JSON array"
+             [@ocaml.warning "-ignored-extra-argument"]
          else
            Ppx_deriving_json_runtime.of_json_error
              "expected a non empty JSON array"
+           [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> poly option)
   
     and poly_of_json =
       (fun x ->
-         match poly_of_json_poly x with
+         match
+           poly_of_json_poly x [@ocaml.warning "-ignored-extra-argument"]
+         with
          | Some x -> x
-         | None -> Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+         | None ->
+             Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+             [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> poly)
   
     let _ = poly_of_json_poly
@@ -468,11 +774,24 @@
     let rec poly_to_json =
       (fun x ->
          match x with
-         | `A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
-         | `B x_0 ->
-             (Obj.magic [| string_to_json "B"; int_to_json x_0 |]
+         | `A ->
+             ((Obj.magic
+                 [|
+                   (string_to_json "A"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
-         | #other as x -> other_to_json x
+         | `B x_0 ->
+             ((Obj.magic
+                 [|
+                   (string_to_json "B"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                   (int_to_json x_0
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
+         | #other as x ->
+             other_to_json x [@ocaml.warning "-ignored-extra-argument"]
         : poly -> Js.Json.t)
   
     let _ = poly_to_json
@@ -490,34 +809,70 @@
   
     let rec c_of_json_poly a_of_json : Js.Json.t -> 'a c option =
      fun x ->
-      if Js.Array.isArray x then
-        let array = (Obj.magic x : Js.Json.t array) in
-        let len = Js.Array.length array in
-        if Stdlib.( > ) len 0 then
-          let tag = Js.Array.unsafe_get array 0 in
-          if Stdlib.( = ) (Js.typeof tag) "string" then
-            let tag = (Obj.magic tag : string) in
-            if Stdlib.( = ) tag "C" then (
-              if Stdlib.( <> ) len 2 then
+      if Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"] then
+        let array =
+          ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+            : Js.Json.t array)
+        in
+        let len =
+          (Js.Array.length array [@ocaml.warning "-ignored-extra-argument"])
+        in
+        if Stdlib.( > ) len 0 [@ocaml.warning "-ignored-extra-argument"]
+        then
+          let tag =
+            (Js.Array.unsafe_get array 0
+             [@ocaml.warning "-ignored-extra-argument"])
+          in
+          if
+            Stdlib.( = )
+              (Js.typeof tag [@ocaml.warning "-ignored-extra-argument"])
+              "string" [@ocaml.warning "-ignored-extra-argument"]
+          then
+            let tag =
+              ((Obj.magic tag [@ocaml.warning "-ignored-extra-argument"])
+                : string)
+            in
+            if
+              Stdlib.( = ) tag "C"
+              [@ocaml.warning "-ignored-extra-argument"]
+            then (
+              if
+                Stdlib.( <> ) len 2
+                [@ocaml.warning "-ignored-extra-argument"]
+              then
                 Ppx_deriving_json_runtime.of_json_error
-                  "expected a JSON array of length 2";
-              Some (`C (a_of_json (Js.Array.unsafe_get array 1))))
+                  "expected a JSON array of length 2"
+                [@ocaml.warning "-ignored-extra-argument"];
+              Some
+                (`C
+                  (a_of_json
+                     (Js.Array.unsafe_get array 1
+                      [@ocaml.warning "-ignored-extra-argument"])
+                   [@ocaml.warning "-ignored-extra-argument"])))
             else None
           else
             Ppx_deriving_json_runtime.of_json_error
               "expected a non empty JSON array with element being a string"
+            [@ocaml.warning "-ignored-extra-argument"]
         else
           Ppx_deriving_json_runtime.of_json_error
             "expected a non empty JSON array"
+          [@ocaml.warning "-ignored-extra-argument"]
       else
         Ppx_deriving_json_runtime.of_json_error
           "expected a non empty JSON array"
+        [@ocaml.warning "-ignored-extra-argument"]
   
     and c_of_json a_of_json : Js.Json.t -> 'a c =
      fun x ->
-      match (c_of_json_poly a_of_json) x with
+      match
+        (c_of_json_poly a_of_json [@ocaml.warning "-ignored-extra-argument"])
+          x [@ocaml.warning "-ignored-extra-argument"]
+      with
       | Some x -> x
-      | None -> Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+      | None ->
+          Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+          [@ocaml.warning "-ignored-extra-argument"]
   
     let _ = c_of_json_poly
     and _ = c_of_json
@@ -528,7 +883,13 @@
      fun x ->
       match x with
       | `C x_0 ->
-          (Obj.magic [| string_to_json "C"; a_to_json x_0 |] : Js.Json.t)
+          ((Obj.magic
+              [|
+                (string_to_json "C"
+                 [@ocaml.warning "-ignored-extra-argument"]);
+                (a_to_json x_0 [@ocaml.warning "-ignored-extra-argument"]);
+              |] [@ocaml.warning "-ignored-extra-argument"])
+            : Js.Json.t)
   
     let _ = c_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
@@ -545,34 +906,74 @@
   
     let rec recur_of_json =
       (fun x ->
-         if Js.Array.isArray x then
-           let array = (Obj.magic x : Js.Json.t array) in
-           let len = Js.Array.length array in
-           if Stdlib.( > ) len 0 then
-             let tag = Js.Array.unsafe_get array 0 in
-             if Stdlib.( = ) (Js.typeof tag) "string" then
-               let tag = (Obj.magic tag : string) in
-               if Stdlib.( = ) tag "A" then (
-                 if Stdlib.( <> ) len 1 then
+         if Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"]
+         then
+           let array =
+             ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t array)
+           in
+           let len =
+             (Js.Array.length array
+              [@ocaml.warning "-ignored-extra-argument"])
+           in
+           if Stdlib.( > ) len 0 [@ocaml.warning "-ignored-extra-argument"]
+           then
+             let tag =
+               (Js.Array.unsafe_get array 0
+                [@ocaml.warning "-ignored-extra-argument"])
+             in
+             if
+               Stdlib.( = )
+                 (Js.typeof tag [@ocaml.warning "-ignored-extra-argument"])
+                 "string" [@ocaml.warning "-ignored-extra-argument"]
+             then
+               let tag =
+                 ((Obj.magic tag [@ocaml.warning "-ignored-extra-argument"])
+                   : string)
+               in
+               if
+                 Stdlib.( = ) tag "A"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 1
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 1";
+                     "expected a JSON array of length 1"
+                   [@ocaml.warning "-ignored-extra-argument"];
                  A)
-               else if Stdlib.( = ) tag "Fix" then (
-                 if Stdlib.( <> ) len 2 then
+               else if
+                 Stdlib.( = ) tag "Fix"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 2
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 2";
-                 Fix (recur_of_json (Js.Array.unsafe_get array 1)))
-               else Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+                     "expected a JSON array of length 2"
+                   [@ocaml.warning "-ignored-extra-argument"];
+                 Fix
+                   (recur_of_json
+                      (Js.Array.unsafe_get array 1
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"]))
+               else
+                 Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+                 [@ocaml.warning "-ignored-extra-argument"]
              else
                Ppx_deriving_json_runtime.of_json_error
                  "expected a non empty JSON array with element being a \
-                  string"
+                  string" [@ocaml.warning "-ignored-extra-argument"]
            else
              Ppx_deriving_json_runtime.of_json_error
                "expected a non empty JSON array"
+             [@ocaml.warning "-ignored-extra-argument"]
          else
            Ppx_deriving_json_runtime.of_json_error
              "expected a non empty JSON array"
+           [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> recur)
   
     let _ = recur_of_json
@@ -582,9 +983,21 @@
     let rec recur_to_json =
       (fun x ->
          match x with
-         | A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
+         | A ->
+             ((Obj.magic
+                 [|
+                   (string_to_json "A"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
          | Fix x_0 ->
-             (Obj.magic [| string_to_json "Fix"; recur_to_json x_0 |]
+             ((Obj.magic
+                 [|
+                   (string_to_json "Fix"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                   (recur_to_json x_0
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : recur -> Js.Json.t)
   
@@ -603,42 +1016,85 @@
   
     let rec polyrecur_of_json_poly =
       (fun x ->
-         if Js.Array.isArray x then
-           let array = (Obj.magic x : Js.Json.t array) in
-           let len = Js.Array.length array in
-           if Stdlib.( > ) len 0 then
-             let tag = Js.Array.unsafe_get array 0 in
-             if Stdlib.( = ) (Js.typeof tag) "string" then
-               let tag = (Obj.magic tag : string) in
-               if Stdlib.( = ) tag "A" then (
-                 if Stdlib.( <> ) len 1 then
+         if Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"]
+         then
+           let array =
+             ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t array)
+           in
+           let len =
+             (Js.Array.length array
+              [@ocaml.warning "-ignored-extra-argument"])
+           in
+           if Stdlib.( > ) len 0 [@ocaml.warning "-ignored-extra-argument"]
+           then
+             let tag =
+               (Js.Array.unsafe_get array 0
+                [@ocaml.warning "-ignored-extra-argument"])
+             in
+             if
+               Stdlib.( = )
+                 (Js.typeof tag [@ocaml.warning "-ignored-extra-argument"])
+                 "string" [@ocaml.warning "-ignored-extra-argument"]
+             then
+               let tag =
+                 ((Obj.magic tag [@ocaml.warning "-ignored-extra-argument"])
+                   : string)
+               in
+               if
+                 Stdlib.( = ) tag "A"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 1
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 1";
+                     "expected a JSON array of length 1"
+                   [@ocaml.warning "-ignored-extra-argument"];
                  Some `A)
-               else if Stdlib.( = ) tag "Fix" then (
-                 if Stdlib.( <> ) len 2 then
+               else if
+                 Stdlib.( = ) tag "Fix"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 2
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 2";
+                     "expected a JSON array of length 2"
+                   [@ocaml.warning "-ignored-extra-argument"];
                  Some
-                   (`Fix (polyrecur_of_json (Js.Array.unsafe_get array 1))))
+                   (`Fix
+                     (polyrecur_of_json
+                        (Js.Array.unsafe_get array 1
+                         [@ocaml.warning "-ignored-extra-argument"])
+                      [@ocaml.warning "-ignored-extra-argument"])))
                else None
              else
                Ppx_deriving_json_runtime.of_json_error
                  "expected a non empty JSON array with element being a \
-                  string"
+                  string" [@ocaml.warning "-ignored-extra-argument"]
            else
              Ppx_deriving_json_runtime.of_json_error
                "expected a non empty JSON array"
+             [@ocaml.warning "-ignored-extra-argument"]
          else
            Ppx_deriving_json_runtime.of_json_error
              "expected a non empty JSON array"
+           [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> polyrecur option)
   
     and polyrecur_of_json =
       (fun x ->
-         match polyrecur_of_json_poly x with
+         match
+           polyrecur_of_json_poly x
+           [@ocaml.warning "-ignored-extra-argument"]
+         with
          | Some x -> x
-         | None -> Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+         | None ->
+             Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+             [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> polyrecur)
   
     let _ = polyrecur_of_json_poly
@@ -649,9 +1105,21 @@
     let rec polyrecur_to_json =
       (fun x ->
          match x with
-         | `A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
+         | `A ->
+             ((Obj.magic
+                 [|
+                   (string_to_json "A"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
          | `Fix x_0 ->
-             (Obj.magic [| string_to_json "Fix"; polyrecur_to_json x_0 |]
+             ((Obj.magic
+                 [|
+                   (string_to_json "Fix"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                   (polyrecur_to_json x_0
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : polyrecur -> Js.Json.t)
   
@@ -670,10 +1138,19 @@
   
     let rec evar_of_json =
       (fun x ->
-         let tag = Ppx_deriving_json_runtime.Primitives.string_of_json x in
-         if Stdlib.( = ) tag "A" then A
-         else if Stdlib.( = ) tag "b_aliased" then B
-         else Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+         let tag =
+           (Ppx_deriving_json_runtime.Primitives.string_of_json x
+            [@ocaml.warning "-ignored-extra-argument"])
+         in
+         if Stdlib.( = ) tag "A" [@ocaml.warning "-ignored-extra-argument"]
+         then A
+         else if
+           Stdlib.( = ) tag "b_aliased"
+           [@ocaml.warning "-ignored-extra-argument"]
+         then B
+         else
+           Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+           [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> evar)
   
     let _ = evar_of_json
@@ -683,8 +1160,18 @@
     let rec evar_to_json =
       (fun x ->
          match x with
-         | A -> (Obj.magic (string_to_json "A") : Js.Json.t)
-         | B -> (Obj.magic (string_to_json "b_aliased") : Js.Json.t)
+         | A ->
+             ((Obj.magic
+                 (string_to_json "A"
+                  [@ocaml.warning "-ignored-extra-argument"])
+               [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
+         | B ->
+             ((Obj.magic
+                 (string_to_json "b_aliased"
+                  [@ocaml.warning "-ignored-extra-argument"])
+               [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
         : evar -> Js.Json.t)
   
     let _ = evar_to_json
@@ -702,17 +1189,29 @@
   
     let rec epoly_of_json_poly =
       (fun x ->
-         let tag = Ppx_deriving_json_runtime.Primitives.string_of_json x in
-         if Stdlib.( = ) tag "A_aliased" then Some `a
-         else if Stdlib.( = ) tag "b" then Some `b
+         let tag =
+           (Ppx_deriving_json_runtime.Primitives.string_of_json x
+            [@ocaml.warning "-ignored-extra-argument"])
+         in
+         if
+           Stdlib.( = ) tag "A_aliased"
+           [@ocaml.warning "-ignored-extra-argument"]
+         then Some `a
+         else if
+           Stdlib.( = ) tag "b" [@ocaml.warning "-ignored-extra-argument"]
+         then Some `b
          else None
         : Js.Json.t -> epoly option)
   
     and epoly_of_json =
       (fun x ->
-         match epoly_of_json_poly x with
+         match
+           epoly_of_json_poly x [@ocaml.warning "-ignored-extra-argument"]
+         with
          | Some x -> x
-         | None -> Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+         | None ->
+             Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+             [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> epoly)
   
     let _ = epoly_of_json_poly
@@ -723,8 +1222,18 @@
     let rec epoly_to_json =
       (fun x ->
          match x with
-         | `a -> (Obj.magic (string_to_json "A_aliased") : Js.Json.t)
-         | `b -> (Obj.magic (string_to_json "b") : Js.Json.t)
+         | `a ->
+             ((Obj.magic
+                 (string_to_json "A_aliased"
+                  [@ocaml.warning "-ignored-extra-argument"])
+               [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
+         | `b ->
+             ((Obj.magic
+                 (string_to_json "b"
+                  [@ocaml.warning "-ignored-extra-argument"])
+               [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
         : epoly -> Js.Json.t)
   
     let _ = epoly_to_json
@@ -742,33 +1251,76 @@
   
     let rec p2_of_json a_of_json b_of_json : Js.Json.t -> ('a, 'b) p2 =
      fun x ->
-      if Js.Array.isArray x then
-        let array = (Obj.magic x : Js.Json.t array) in
-        let len = Js.Array.length array in
-        if Stdlib.( > ) len 0 then
-          let tag = Js.Array.unsafe_get array 0 in
-          if Stdlib.( = ) (Js.typeof tag) "string" then
-            let tag = (Obj.magic tag : string) in
-            if Stdlib.( = ) tag "A" then (
-              if Stdlib.( <> ) len 2 then
+      if Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"] then
+        let array =
+          ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+            : Js.Json.t array)
+        in
+        let len =
+          (Js.Array.length array [@ocaml.warning "-ignored-extra-argument"])
+        in
+        if Stdlib.( > ) len 0 [@ocaml.warning "-ignored-extra-argument"]
+        then
+          let tag =
+            (Js.Array.unsafe_get array 0
+             [@ocaml.warning "-ignored-extra-argument"])
+          in
+          if
+            Stdlib.( = )
+              (Js.typeof tag [@ocaml.warning "-ignored-extra-argument"])
+              "string" [@ocaml.warning "-ignored-extra-argument"]
+          then
+            let tag =
+              ((Obj.magic tag [@ocaml.warning "-ignored-extra-argument"])
+                : string)
+            in
+            if
+              Stdlib.( = ) tag "A"
+              [@ocaml.warning "-ignored-extra-argument"]
+            then (
+              if
+                Stdlib.( <> ) len 2
+                [@ocaml.warning "-ignored-extra-argument"]
+              then
                 Ppx_deriving_json_runtime.of_json_error
-                  "expected a JSON array of length 2";
-              A (a_of_json (Js.Array.unsafe_get array 1)))
-            else if Stdlib.( = ) tag "B" then (
-              if Stdlib.( <> ) len 2 then
+                  "expected a JSON array of length 2"
+                [@ocaml.warning "-ignored-extra-argument"];
+              A
+                (a_of_json
+                   (Js.Array.unsafe_get array 1
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 [@ocaml.warning "-ignored-extra-argument"]))
+            else if
+              Stdlib.( = ) tag "B"
+              [@ocaml.warning "-ignored-extra-argument"]
+            then (
+              if
+                Stdlib.( <> ) len 2
+                [@ocaml.warning "-ignored-extra-argument"]
+              then
                 Ppx_deriving_json_runtime.of_json_error
-                  "expected a JSON array of length 2";
-              B (b_of_json (Js.Array.unsafe_get array 1)))
-            else Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+                  "expected a JSON array of length 2"
+                [@ocaml.warning "-ignored-extra-argument"];
+              B
+                (b_of_json
+                   (Js.Array.unsafe_get array 1
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 [@ocaml.warning "-ignored-extra-argument"]))
+            else
+              Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+              [@ocaml.warning "-ignored-extra-argument"]
           else
             Ppx_deriving_json_runtime.of_json_error
               "expected a non empty JSON array with element being a string"
+            [@ocaml.warning "-ignored-extra-argument"]
         else
           Ppx_deriving_json_runtime.of_json_error
             "expected a non empty JSON array"
+          [@ocaml.warning "-ignored-extra-argument"]
       else
         Ppx_deriving_json_runtime.of_json_error
           "expected a non empty JSON array"
+        [@ocaml.warning "-ignored-extra-argument"]
   
     let _ = p2_of_json
   
@@ -778,9 +1330,21 @@
      fun x ->
       match x with
       | A x_0 ->
-          (Obj.magic [| string_to_json "A"; a_to_json x_0 |] : Js.Json.t)
+          ((Obj.magic
+              [|
+                (string_to_json "A"
+                 [@ocaml.warning "-ignored-extra-argument"]);
+                (a_to_json x_0 [@ocaml.warning "-ignored-extra-argument"]);
+              |] [@ocaml.warning "-ignored-extra-argument"])
+            : Js.Json.t)
       | B x_0 ->
-          (Obj.magic [| string_to_json "B"; b_to_json x_0 |] : Js.Json.t)
+          ((Obj.magic
+              [|
+                (string_to_json "B"
+                 [@ocaml.warning "-ignored-extra-argument"]);
+                (b_to_json x_0 [@ocaml.warning "-ignored-extra-argument"]);
+              |] [@ocaml.warning "-ignored-extra-argument"])
+            : Js.Json.t)
   
     let _ = p2_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
@@ -801,21 +1365,43 @@
          if
            Stdlib.not
              (Stdlib.( && )
-                (Stdlib.( = ) (Js.typeof x) "object")
+                (Stdlib.( = )
+                   (Js.typeof x [@ocaml.warning "-ignored-extra-argument"])
+                   "object" [@ocaml.warning "-ignored-extra-argument"])
                 (Stdlib.( && )
-                   (Stdlib.not (Js.Array.isArray x))
                    (Stdlib.not
-                      (Stdlib.( == ) (Obj.magic x : 'a Js.null) Js.null))))
+                      (Js.Array.isArray x
+                       [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                   (Stdlib.not
+                      (Stdlib.( == )
+                         ((Obj.magic x
+                           [@ocaml.warning "-ignored-extra-argument"])
+                           : 'a Js.null)
+                         Js.null [@ocaml.warning "-ignored-extra-argument"])
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 [@ocaml.warning "-ignored-extra-argument"])
+              [@ocaml.warning "-ignored-extra-argument"])
+           [@ocaml.warning "-ignored-extra-argument"]
          then
-           Ppx_deriving_json_runtime.of_json_error "expected a JSON object";
-         let fs = (Obj.magic x : < a : Js.Json.t Js.undefined > Js.t) in
+           Ppx_deriving_json_runtime.of_json_error "expected a JSON object"
+           [@ocaml.warning "-ignored-extra-argument"];
+         let fs =
+           ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+             : < a : Js.Json.t Js.undefined > Js.t)
+         in
          {
            a =
-             (match Js.Undefined.toOption fs##a with
-             | Stdlib.Option.Some v -> int_of_json v
+             (match
+                Js.Undefined.toOption (Js.OO.unsafe_downgrade fs)#a
+                [@ocaml.warning "-ignored-extra-argument"]
+              with
+             | Stdlib.Option.Some v ->
+                 int_of_json v [@ocaml.warning "-ignored-extra-argument"]
              | Stdlib.Option.None ->
                  Ppx_deriving_json_runtime.of_json_error
-                   "missing field \"a\"");
+                   "missing field \"a\""
+                 [@ocaml.warning "-ignored-extra-argument"]);
          }
         : Js.Json.t -> allow_extra_fields)
   
@@ -827,7 +1413,20 @@
       (fun x ->
          match x with
          | { a = x_a } ->
-             (Obj.magic [%mel.obj { a = int_to_json x_a }] : Js.Json.t)
+             ((Obj.magic
+                 (let module J = struct
+                    external unsafe_expr : a:'a0 -> < a : 'a0 > Js.t
+                      = ""
+                        "\132\149\166\190\000\000\000\b\000\000\000\005\000\000\000\012\000\000\000\012\145\160\160A\144!a@"
+                    [@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                  end in
+                 (J.unsafe_expr
+                    ~a:
+                      (int_to_json x_a
+                       [@ocaml.warning "-ignored-extra-argument"])
+                  [@ocaml.warning "-ignored-extra-argument"]))
+               [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t)
         : allow_extra_fields -> Js.Json.t)
   
     let _ = allow_extra_fields_to_json
@@ -846,54 +1445,110 @@
   
     let rec allow_extra_fields2_of_json =
       (fun x ->
-         if Js.Array.isArray x then
-           let array = (Obj.magic x : Js.Json.t array) in
-           let len = Js.Array.length array in
-           if Stdlib.( > ) len 0 then
-             let tag = Js.Array.unsafe_get array 0 in
-             if Stdlib.( = ) (Js.typeof tag) "string" then
-               let tag = (Obj.magic tag : string) in
-               if Stdlib.( = ) tag "A" then (
-                 if Stdlib.( <> ) len 2 then
+         if Js.Array.isArray x [@ocaml.warning "-ignored-extra-argument"]
+         then
+           let array =
+             ((Obj.magic x [@ocaml.warning "-ignored-extra-argument"])
+               : Js.Json.t array)
+           in
+           let len =
+             (Js.Array.length array
+              [@ocaml.warning "-ignored-extra-argument"])
+           in
+           if Stdlib.( > ) len 0 [@ocaml.warning "-ignored-extra-argument"]
+           then
+             let tag =
+               (Js.Array.unsafe_get array 0
+                [@ocaml.warning "-ignored-extra-argument"])
+             in
+             if
+               Stdlib.( = )
+                 (Js.typeof tag [@ocaml.warning "-ignored-extra-argument"])
+                 "string" [@ocaml.warning "-ignored-extra-argument"]
+             then
+               let tag =
+                 ((Obj.magic tag [@ocaml.warning "-ignored-extra-argument"])
+                   : string)
+               in
+               if
+                 Stdlib.( = ) tag "A"
+                 [@ocaml.warning "-ignored-extra-argument"]
+               then (
+                 if
+                   Stdlib.( <> ) len 2
+                   [@ocaml.warning "-ignored-extra-argument"]
+                 then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON array of length 2";
-                 let fs = Js.Array.unsafe_get array 1 in
+                     "expected a JSON array of length 2"
+                   [@ocaml.warning "-ignored-extra-argument"];
+                 let fs =
+                   (Js.Array.unsafe_get array 1
+                    [@ocaml.warning "-ignored-extra-argument"])
+                 in
                  if
                    Stdlib.not
                      (Stdlib.( && )
-                        (Stdlib.( = ) (Js.typeof fs) "object")
+                        (Stdlib.( = )
+                           (Js.typeof fs
+                            [@ocaml.warning "-ignored-extra-argument"])
+                           "object"
+                         [@ocaml.warning "-ignored-extra-argument"])
                         (Stdlib.( && )
-                           (Stdlib.not (Js.Array.isArray fs))
+                           (Stdlib.not
+                              (Js.Array.isArray fs
+                               [@ocaml.warning "-ignored-extra-argument"])
+                            [@ocaml.warning "-ignored-extra-argument"])
                            (Stdlib.not
                               (Stdlib.( == )
-                                 (Obj.magic fs : 'a Js.null)
-                                 Js.null))))
+                                 ((Obj.magic fs
+                                   [@ocaml.warning
+                                     "-ignored-extra-argument"])
+                                   : 'a Js.null)
+                                 Js.null
+                               [@ocaml.warning "-ignored-extra-argument"])
+                            [@ocaml.warning "-ignored-extra-argument"])
+                         [@ocaml.warning "-ignored-extra-argument"])
+                      [@ocaml.warning "-ignored-extra-argument"])
+                   [@ocaml.warning "-ignored-extra-argument"]
                  then
                    Ppx_deriving_json_runtime.of_json_error
-                     "expected a JSON object";
+                     "expected a JSON object"
+                   [@ocaml.warning "-ignored-extra-argument"];
                  let fs =
-                   (Obj.magic fs : < a : Js.Json.t Js.undefined > Js.t)
+                   ((Obj.magic fs [@ocaml.warning "-ignored-extra-argument"])
+                     : < a : Js.Json.t Js.undefined > Js.t)
                  in
                  A
                    {
                      a =
-                       (match Js.Undefined.toOption fs##a with
-                       | Stdlib.Option.Some v -> int_of_json v
+                       (match
+                          Js.Undefined.toOption
+                            (Js.OO.unsafe_downgrade fs)#a
+                          [@ocaml.warning "-ignored-extra-argument"]
+                        with
+                       | Stdlib.Option.Some v ->
+                           int_of_json v
+                           [@ocaml.warning "-ignored-extra-argument"]
                        | Stdlib.Option.None ->
                            Ppx_deriving_json_runtime.of_json_error
-                             "missing field \"a\"");
+                             "missing field \"a\""
+                           [@ocaml.warning "-ignored-extra-argument"]);
                    })
-               else Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+               else
+                 Ppx_deriving_json_runtime.of_json_error "invalid JSON"
+                 [@ocaml.warning "-ignored-extra-argument"]
              else
                Ppx_deriving_json_runtime.of_json_error
                  "expected a non empty JSON array with element being a \
-                  string"
+                  string" [@ocaml.warning "-ignored-extra-argument"]
            else
              Ppx_deriving_json_runtime.of_json_error
                "expected a non empty JSON array"
+             [@ocaml.warning "-ignored-extra-argument"]
          else
            Ppx_deriving_json_runtime.of_json_error
              "expected a non empty JSON array"
+           [@ocaml.warning "-ignored-extra-argument"]
         : Js.Json.t -> allow_extra_fields2)
   
     let _ = allow_extra_fields2_of_json
@@ -904,11 +1559,25 @@
       (fun x ->
          match x with
          | A { a = x_a } ->
-             (Obj.magic
-                [|
-                  string_to_json "A";
-                  (Obj.magic [%mel.obj { a = int_to_json x_a }] : Js.Json.t);
-                |]
+             ((Obj.magic
+                 [|
+                   (string_to_json "A"
+                    [@ocaml.warning "-ignored-extra-argument"]);
+                   ((Obj.magic
+                       (let module J = struct
+                          external unsafe_expr : a:'a0 -> < a : 'a0 > Js.t
+                            = ""
+                              "\132\149\166\190\000\000\000\b\000\000\000\005\000\000\000\012\000\000\000\012\145\160\160A\144!a@"
+                          [@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                        end in
+                       (J.unsafe_expr
+                          ~a:
+                            (int_to_json x_a
+                             [@ocaml.warning "-ignored-extra-argument"])
+                        [@ocaml.warning "-ignored-extra-argument"]))
+                     [@ocaml.warning "-ignored-extra-argument"])
+                     : Js.Json.t);
+                 |] [@ocaml.warning "-ignored-extra-argument"])
                : Js.Json.t)
         : allow_extra_fields2 -> Js.Json.t)
   


### PR DESCRIPTION
Similar to #15, in this case adding `melange.ppx` to `libraries` allows to have it always linked, so users don't need to add it themselves, as the PPX generated code includes `@mel` external definitions.

- See [first commit](https://github.com/melange-community/melange-json/commit/1c48ad21945217d8fa888760b478b2a8e2b6915a) for the kind of errors users would get before if they didn't add `melange.ppx`.
- [Second commit](https://github.com/melange-community/melange-json/commit/848f6813f6c700b26cc60d72488f252cce208935) for the fix (a bunch of `-ignored-extra-argument` silencing is added for some reason).