### PR TITLE
ppx: add [@drop_default] for record fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
   ([#11](https://github.com/melange-community/melange-json/pull/11))
 - Add `melange-json-native` package
   ([#12](https://github.com/melange-community/melange-json/pull/12))
+- Add `[@drop_default]` attribute to drop `None` values from JSON
+  representation
+  ([#17](https://github.com/melange-community/melange-json/pull/17))
 
 ## 1.2.0 (2024-08-16)
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,22 @@ let t = of_json (Json.parseOrRaise {|{"a": 42}|})
 (* t = { a = 42; b = None; } *)
 ```
 
+#### `[@json.drop_default]`: drop default values from JSON
+
+When a field has `[@option]` attribute one can use `[@json.drop_default]`
+attribute to make the generated `to_json` function to drop the field if it's
+value is `None`:
+
+```ocaml
+type t = {
+  a: int;
+  b: string option [@json.option] [@json.drop_default];
+} [@@deriving to_json]
+
+let t = to_json { a = 1; b = None; }
+(* {"a": 1} *)
+```
+
 #### `[@json.key "S"]`: customizing keys for record fields
 
 You can specify custom keys for record fields using the `[@json.key E]`

--- a/ppx/browser/dune
+++ b/ppx/browser/dune
@@ -1,11 +1,7 @@
 (library
  (public_name melange-json.ppx)
  (name ppx_deriving_json_js)
- (modules
-  :standard
-  \
-  ppx_deriving_json_runtime
-  ppx_deriving_json_js_test)
+ (modules :standard \ ppx_deriving_json_runtime ppx_deriving_json_js_test)
  (libraries ppxlib)
  (ppx_runtime_libraries melange-json.ppx-runtime)
  (preprocess

--- a/ppx/native/ppx_deriving_json_common.ml
+++ b/ppx/native/ppx_deriving_json_common.ml
@@ -51,6 +51,13 @@ let ld_attr_json_default =
        Ast_pattern.(single_expr_payload __)
        (fun x -> x))
 
+let ld_attr_json_drop_default =
+  Attribute.get
+    (Attribute.declare "json.drop_default"
+       Attribute.Context.label_declaration
+       Ast_pattern.(pstr nil)
+       ())
+
 let ld_attr_default ld =
   match ld_attr_json_default ld with
   | Some e -> Some e
@@ -60,3 +67,12 @@ let ld_attr_default ld =
           let loc = ld.pld_loc in
           Some [%expr Stdlib.Option.None]
       | None -> None)
+
+let ld_drop_default ld =
+  let loc = ld.pld_loc in
+  match ld_attr_json_drop_default ld, ld_attr_json_option ld with
+  | Some (), None ->
+      Ppx_deriving_tools.error ~loc
+        "found [@drop_default] attribute without [@option]"
+  | Some (), Some () -> `Drop_option
+  | None, _ -> `No

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -16,6 +16,7 @@ type epoly = [ `a [@json.as "A_aliased"] | `b ] [@@deriving json]
 type ('a, 'b) p2 = A of 'a | B of 'b [@@deriving json]
 type allow_extra_fields = {a: int} [@@deriving json] [@@json.allow_extra_fields]
 type allow_extra_fields2 = A of {a: int} [@json.allow_extra_fields] [@@deriving json]
+type drop_default_option = { a: int; b_opt: int option; [@option] [@json.drop_default] } [@@deriving json]
 
 module Cases = struct 
   type json = Ppx_deriving_json_runtime.t
@@ -47,6 +48,8 @@ module Cases = struct
     C ({|["B","ok"]|}, p2_of_json int_of_json string_of_json, p2_to_json int_to_json string_to_json, B "ok");
     C ({|{"a":1,"b":2}|}, allow_extra_fields_of_json, allow_extra_fields_to_json, {a=1});
     C ({|["A",{"a":1,"b":2}]|}, allow_extra_fields2_of_json, allow_extra_fields2_to_json, A {a=1});
+    C ({|{"a":1}|}, drop_default_option_of_json, drop_default_option_to_json, {a=1; b_opt=None});
+    C ({|{"a":1,"b_opt":2}|}, drop_default_option_of_json, drop_default_option_to_json, {a=1; b_opt=Some 2});
   ]
   let run' ~json_of_string ~json_to_string (C (data, of_json, to_json, v)) =
     print_endline (Printf.sprintf "JSON    DATA: %s" data);

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -78,3 +78,7 @@
   JSON REPRINT: {"a":1}
   JSON    DATA: ["A",{"a":1,"b":2}]
   JSON REPRINT: ["A",{"a":1}]
+  JSON    DATA: {"a":1}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: {"a":1,"b_opt":2}
+  JSON REPRINT: {"a":1,"b_opt":2}

--- a/ppx/test/ppx_deriving_json_js_errors.t
+++ b/ppx/test/ppx_deriving_json_js_errors.t
@@ -1,0 +1,6 @@
+
+
+  $ echo 'type t = { a: int option; [@drop_default] } [@@deriving json]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  Fatal error: exception Ppx_deriving_json_js__Ppx_deriving_tools.Error(_, "found [@drop_default] attribute without [@option]")
+  [2]
+

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -70,3 +70,7 @@
   JSON REPRINT: {"a":1}
   JSON    DATA: ["A",{"a":1,"b":2}]
   JSON REPRINT: ["A",{"a":1}]
+  JSON    DATA: {"a":1}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: {"a":1,"b_opt":2}
+  JSON REPRINT: {"a":1,"b_opt":2}

--- a/ppx/test/ppx_deriving_json_native_errors.t
+++ b/ppx/test/ppx_deriving_json_native_errors.t
@@ -1,0 +1,6 @@
+
+
+  $ echo 'type t = { a: int option; [@drop_default] } [@@deriving json]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  Fatal error: exception Ppx_deriving_json_native__Ppx_deriving_tools.Error(_, "found [@drop_default] attribute without [@option]")
+  [2]
+


### PR DESCRIPTION
For now it only works for record fields annotated with `[@option]`, by dropping the field from JSON repr when the record value is `None`.

What's missing is to also support `[@drop_default]` for fields annotated by `[@default X]` but we need to decide how to check for equality between the default value and the field value.

One nice idea I had is to generate code like this:

```ocaml
type t = { a : int [@default 0] [@drop_default] }
...
let bnds =
  match [%equal int] a 0 with
  | true -> bnds
  | false -> ("a", a)::bnds
in
...
```

but this means this ppx will depend on another ppx which provides `[%equal t]` deriver but sadly `ppx_compare` doesn't work with melange now.