### PR TITLE
ppx: fix float_of_json to handle `Int

### DIFF
--- a/ppx/native/ppx_deriving_json_runtime.ml
+++ b/ppx/native/ppx_deriving_json_runtime.ml
@@ -31,7 +31,7 @@ module Of_json = struct
   let string_of_json = Yojson.Basic.Util.to_string
   let bool_of_json = Yojson.Basic.Util.to_bool
   let int_of_json = Yojson.Basic.Util.to_int
-  let float_of_json = Yojson.Basic.Util.to_float
+  let float_of_json = Yojson.Basic.Util.to_number
 
   let unit_of_json = function
     | `Null -> ()

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -1,4 +1,5 @@
 type user = int [@@deriving json]
+type floaty = float [@@deriving json]
 type 'a param = 'a [@@deriving json]
 type opt = string option [@@deriving json]
 type res = (int, string) result [@@deriving json]
@@ -23,6 +24,9 @@ module Cases = struct
   type of_json = C : string * (json -> 'a) * ('a -> json) * 'a -> of_json
   let of_json_cases = [
     C ({|1|}, user_of_json, user_to_json, 1);
+    C ({|1.1|}, floaty_of_json, floaty_to_json, 1.1);
+    C ({|1.0|}, floaty_of_json, floaty_to_json, 1.0);
+    C ({|42|}, floaty_of_json, floaty_to_json, 42.0);
     C ({|"OK"|}, (param_of_json string_of_json), (param_to_json string_to_json), "OK");
     C ({|"some"|}, opt_of_json, opt_to_json, (Some "some"));
     C ({|["Ok", 1]|}, res_of_json, res_to_json, Ok 1);

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -28,6 +28,12 @@
   $ node ./_build/default/output/main.js
   JSON    DATA: 1
   JSON REPRINT: 1
+  JSON    DATA: 1.1
+  JSON REPRINT: 1.1
+  JSON    DATA: 1.0
+  JSON REPRINT: 1
+  JSON    DATA: 42
+  JSON REPRINT: 42
   JSON    DATA: "OK"
   JSON REPRINT: "OK"
   JSON    DATA: "some"

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -20,6 +20,12 @@
   $ dune exec ./main.exe
   JSON    DATA: 1
   JSON REPRINT: 1
+  JSON    DATA: 1.1
+  JSON REPRINT: 1.1
+  JSON    DATA: 1.0
+  JSON REPRINT: 1.0
+  JSON    DATA: 42
+  JSON REPRINT: 42.0
   JSON    DATA: "OK"
   JSON REPRINT: "OK"
   JSON    DATA: "some"


### PR DESCRIPTION
In browser `JSON.stringify(1.0)` will yield `1` which will be parsed as ``(`Int 1)`` by Yojson and finally, used before this commit, `Yojson.Basic.Util.to_float` will fail on it as it expects ``(`Float n)``.

So this commit changes `float_of_json` to be `Yojson.Basic.Util.to_number` which handles both ``(`Float n)`` and ``(`Int n)``.