### PR TITLE
ppx: rename [@json.as] into [@json.name]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   ([#13](https://github.com/melange-community/melange-json/pull/13))
 - PPX: Add `yojson` as runtime dep for the native version
   ([#15](https://github.com/melange-community/melange-json/pull/15))
+- PPX: Rename `[@json.as]` to `[@json.name]`
 
 ## 1.3.0 (2024-08-28)
 

--- a/README.md
+++ b/README.md
@@ -283,13 +283,13 @@ let t = of_json (Json.parseOrRaise {|{"A": 42, "B": "foo"}|})
 (* t = { a = 42; b = "foo"; } *)
 ```
 
-#### `[@json.as "S"]`: customizing the representation of a variant case
+#### `[@json.name "S"]`: customizing the representation of a variant case
 
-You can specify custom representation for a variant case using the `[@json.as
+You can specify custom representation for a variant case using the `[@json.name
 E]` attribute:
 
 ```ocaml
-type t = A | B [@json.as "bbb"] [@@deriving json]
+type t = A | B [@json.name "bbb"] [@@deriving json]
 
 let json = to_json B
 (* "bbb" *)

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -138,14 +138,14 @@ module Of_json = struct
     match c with
     | Vcs_enum (n, ctx) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name ctx) in
         [%expr
           if Stdlib.( = ) tag [%e estring ~loc:n.loc n.txt] then
             [%e make None]
           else [%e next]]
     | Vcs_record (n, r) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as r.rcd_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name r.rcd_ctx) in
         [%expr
           if Stdlib.( = ) tag [%e estring ~loc:n.loc n.txt] then (
             [%e ensure_json_array_len ~loc 2 [%expr len]];
@@ -157,7 +157,7 @@ module Of_json = struct
           else [%e next]]
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as t.tpl_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
         [%expr
           if Stdlib.( = ) tag [%e estring ~loc:n.loc n.txt] then (
@@ -213,18 +213,18 @@ module To_json = struct
     match c with
     | Vcs_enum (n, ctx) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name ctx) in
         let tag = [%expr string_to_json [%e estring ~loc:n.loc n.txt]] in
         as_json ~loc tag
     | Vcs_record (n, r) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as r.rcd_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name r.rcd_ctx) in
         let tag = [%expr string_to_json [%e estring ~loc:n.loc n.txt]] in
         let es = [ derive_of_record derive r es ] in
         as_json ~loc (pexp_array ~loc (tag :: es))
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as t.tpl_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let tag = [%expr string_to_json [%e estring ~loc:n.loc n.txt]] in
         let es = List.map2 t.tpl_types es ~f:derive in
         as_json ~loc (pexp_array ~loc (tag :: es))

--- a/ppx/native/ppx_deriving_json_common.ml
+++ b/ppx/native/ppx_deriving_json_common.ml
@@ -9,14 +9,16 @@ let get_of_variant ?mark_as_seen ~variant ~polyvariant = function
   | Vrt_ctx_variant ctx -> Attribute.get ?mark_as_seen variant ctx
   | Vrt_ctx_polyvariant ctx -> Attribute.get ?mark_as_seen polyvariant ctx
 
-let attr_json_as ctx =
-  Attribute.declare "json.as" ctx
+let attr_json_name ctx =
+  Attribute.declare "json.name" ctx
     Ast_pattern.(single_expr_payload (estring __'))
     (fun x -> x)
 
-let vcs_attr_json_as =
-  let variant = attr_json_as Attribute.Context.constructor_declaration in
-  let polyvariant = attr_json_as Attribute.Context.rtag in
+let vcs_attr_json_name =
+  let variant =
+    attr_json_name Attribute.Context.constructor_declaration
+  in
+  let polyvariant = attr_json_name Attribute.Context.rtag in
   get_of_variant_case ~variant ~polyvariant
 
 let ld_attr_json_key =

--- a/ppx/native/ppx_deriving_json_native.ml
+++ b/ppx/native/ppx_deriving_json_native.ml
@@ -135,11 +135,11 @@ module Of_json = struct
     match vcs with
     | Vcs_enum (n, ctx) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name ctx) in
         [%pat? `String [%p pstring ~loc:n.loc n.txt]] --> make None
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as t.tpl_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
         if arity = 0 then
           [%pat? `List [ `String [%p pstring ~loc:n.loc n.txt] ]]
@@ -151,7 +151,7 @@ module Of_json = struct
           --> make (Some (build_tuple ~loc derive xexprs t.tpl_types))
     | Vcs_record (n, t) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as t.rcd_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name t.rcd_ctx) in
         let allow_extra_fields =
           match t.rcd_ctx with
           | Vcs_ctx_variant cd ->
@@ -214,18 +214,18 @@ module To_json = struct
     match vcs with
     | Vcs_enum (n, ctx) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name ctx) in
         [%expr `String [%e estring ~loc:n.loc n.txt]]
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as t.tpl_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         [%expr
           `List
             (`String [%e estring ~loc:n.loc n.txt]
             :: [%e elist ~loc (List.map2 t.tpl_types es ~f:derive)])]
     | Vcs_record (n, t) ->
         let loc = n.loc in
-        let n = Option.value ~default:n (vcs_attr_json_as t.rcd_ctx) in
+        let n = Option.value ~default:n (vcs_attr_json_name t.rcd_ctx) in
         [%expr
           `List
             (`String [%e estring ~loc:n.loc n.txt]

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -12,14 +12,14 @@ type other = [ `C ] [@@deriving json] type poly = [ `A | `B of int | other ] [@@
 type 'a c = [ `C of 'a ] [@@deriving json]
 type recur = A | Fix of recur [@@deriving json]
 type polyrecur = [ `A | `Fix of polyrecur ] [@@deriving json]
-type evar = A | B [@json.as "b_aliased"] [@@deriving json]
-type epoly = [ `a [@json.as "A_aliased"] | `b ] [@@deriving json]
+type evar = A | B [@json.name "b_aliased"] [@@deriving json]
+type epoly = [ `a [@json.name "A_aliased"] | `b ] [@@deriving json]
 type ('a, 'b) p2 = A of 'a | B of 'b [@@deriving json]
 type allow_extra_fields = {a: int} [@@deriving json] [@@json.allow_extra_fields]
 type allow_extra_fields2 = A of {a: int} [@json.allow_extra_fields] [@@deriving json]
 type drop_default_option = { a: int; b_opt: int option; [@option] [@json.drop_default] } [@@deriving json]
 
-module Cases = struct 
+module Cases = struct
   type json = Ppx_deriving_json_runtime.t
   type of_json = C : string * (json -> 'a) * ('a -> json) * 'a -> of_json
   let of_json_cases = [
@@ -66,4 +66,3 @@ module Cases = struct
   let run ~json_of_string ~json_to_string () =
     List.iter (run' ~json_of_string ~json_to_string) of_json_cases
 end
-

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -659,9 +659,9 @@
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
 
   $ cat <<"EOF" | run
-  > type evar = A | B [@json.as "b_aliased"] [@@deriving json]
+  > type evar = A | B [@json.name "b_aliased"] [@@deriving json]
   > EOF
-  type evar = A | B [@json.as "b_aliased"] [@@deriving json]
+  type evar = A | B [@json.name "b_aliased"] [@@deriving json]
   
   include struct
     let _ = fun (_ : evar) -> ()
@@ -691,9 +691,9 @@
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
 
   $ cat <<"EOF" | run
-  > type epoly = [ `a [@json.as "A_aliased"] | `b ] [@@deriving json]
+  > type epoly = [ `a [@json.name "A_aliased"] | `b ] [@@deriving json]
   > EOF
-  type epoly = [ `a [@json.as "A_aliased"] | `b ] [@@deriving json]
+  type epoly = [ `a [@json.name "A_aliased"] | `b ] [@@deriving json]
   
   include struct
     let _ = fun (_ : epoly) -> ()
@@ -985,4 +985,3 @@
   
     let _ = drop_default_option_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
-

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -541,9 +541,9 @@
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
 
   $ cat <<"EOF" | run
-  > type evar = A | B [@json.as "b_aliased"] [@@deriving json]
+  > type evar = A | B [@json.name "b_aliased"] [@@deriving json]
   > EOF
-  type evar = A | B [@json.as "b_aliased"] [@@deriving json]
+  type evar = A | B [@json.name "b_aliased"] [@@deriving json]
   
   include struct
     let _ = fun (_ : evar) -> ()
@@ -570,9 +570,9 @@
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
 
   $ cat <<"EOF" | run
-  > type epoly = [ `a [@json.as "A_aliased"] | `b ] [@@deriving json]
+  > type epoly = [ `a [@json.name "A_aliased"] | `b ] [@@deriving json]
   > EOF
-  type epoly = [ `a [@json.as "A_aliased"] | `b ] [@@deriving json]
+  type epoly = [ `a [@json.name "A_aliased"] | `b ] [@@deriving json]
   
   include struct
     let _ = fun (_ : epoly) -> ()
@@ -823,4 +823,3 @@
   
     let _ = drop_default_option_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
-


### PR DESCRIPTION
Fixes #21

I've made it a breaking change. But maybe it's better to support both `as` and `name` for a while?