### PR TITLE
ppx: remove `string_to_json` usage on js side

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
   ([#30](https://github.com/melange-community/melange-json/pull/30))
 - PPX: add support for `int64` in the runtime
   ([#33](https://github.com/melange-community/melange-json/pull/33))
-- PPX: qualify `string_to_json` usage on js side
+- PPX: remove `string_to_json` usage on js side
   ([#35](https://github.com/melange-community/melange-json/pull/35))
 
 ## 1.3.0 (2024-08-28)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
   ([#30](https://github.com/melange-community/melange-json/pull/30))
 - PPX: add support for `int64` in the runtime
   ([#33](https://github.com/melange-community/melange-json/pull/33))
+- PPX: qualify `string_to_json` usage on js side
+  ([#35](https://github.com/melange-community/melange-json/pull/35))
 
 ## 1.3.0 (2024-08-28)
 

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -194,21 +194,13 @@ module To_json = struct
     | Vcs_record (n, r) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name r.rcd_ctx) in
-        let tag =
-          [%expr
-            Ppx_deriving_json_runtime.Primitives.string_to_json
-              [%e estring ~loc:n.loc n.txt]]
-        in
+        let tag = [%expr (Obj.magic [%e estring ~loc:n.loc n.txt]: Js.Json.t)] in
         let es = [ derive_of_record derive r es ] in
         as_json ~loc (pexp_array ~loc (tag :: es))
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
-        let tag =
-          [%expr
-            Ppx_deriving_json_runtime.Primitives.string_to_json
-              [%e estring ~loc:n.loc n.txt]]
-        in
+        let tag = [%expr (Obj.magic [%e estring ~loc:n.loc n.txt]: Js.Json.t)] in
         let es = List.map2 t.tpl_types es ~f:derive in
         as_json ~loc (pexp_array ~loc (tag :: es))
 

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -194,13 +194,21 @@ module To_json = struct
     | Vcs_record (n, r) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name r.rcd_ctx) in
-        let tag = [%expr string_to_json [%e estring ~loc:n.loc n.txt]] in
+        let tag =
+          [%expr
+            Ppx_deriving_json_runtime.Primitives.string_to_json
+              [%e estring ~loc:n.loc n.txt]]
+        in
         let es = [ derive_of_record derive r es ] in
         as_json ~loc (pexp_array ~loc (tag :: es))
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
-        let tag = [%expr string_to_json [%e estring ~loc:n.loc n.txt]] in
+        let tag =
+          [%expr
+            Ppx_deriving_json_runtime.Primitives.string_to_json
+              [%e estring ~loc:n.loc n.txt]]
+        in
         let es = List.map2 t.tpl_types es ~f:derive in
         as_json ~loc (pexp_array ~loc (tag :: es))
 

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -406,14 +406,23 @@
     let rec sum_to_json =
       (fun x ->
          match x with
-         | A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
+         | A ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
+                |]
+               : Js.Json.t)
          | B x_0 ->
-             (Obj.magic [| string_to_json "B"; int_to_json x_0 |]
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "B";
+                  int_to_json x_0;
+                |]
                : Js.Json.t)
          | C { name = x_name } ->
              (Obj.magic
                 [|
-                  string_to_json "C";
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "C";
                   (Obj.magic [%mel.obj { name = string_to_json x_name }]
                     : Js.Json.t);
                 |]
@@ -472,7 +481,9 @@
          | S2 (x_0, x_1) ->
              (Obj.magic
                 [|
-                  string_to_json "S2"; int_to_json x_0; string_to_json x_1;
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "S2";
+                  int_to_json x_0;
+                  string_to_json x_1;
                 |]
                : Js.Json.t)
         : sum2 -> Js.Json.t)
@@ -532,7 +543,12 @@
     let rec other_to_json =
       (fun x ->
          match x with
-         | `C -> (Obj.magic [| string_to_json "C" |] : Js.Json.t)
+         | `C ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "C";
+                |]
+               : Js.Json.t)
         : other -> Js.Json.t)
   
     let _ = other_to_json
@@ -595,9 +611,18 @@
     let rec poly_to_json =
       (fun x ->
          match x with
-         | `A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
+         | `A ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
+                |]
+               : Js.Json.t)
          | `B x_0 ->
-             (Obj.magic [| string_to_json "B"; int_to_json x_0 |]
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "B";
+                  int_to_json x_0;
+                |]
                : Js.Json.t)
          | #other as x -> other_to_json x
         : poly -> Js.Json.t)
@@ -663,7 +688,9 @@
          | `P2 (x_0, x_1) ->
              (Obj.magic
                 [|
-                  string_to_json "P2"; int_to_json x_0; string_to_json x_1;
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "P2";
+                  int_to_json x_0;
+                  string_to_json x_1;
                 |]
                : Js.Json.t)
         : poly2 -> Js.Json.t)
@@ -721,7 +748,12 @@
      fun x ->
       match x with
       | `C x_0 ->
-          (Obj.magic [| string_to_json "C"; a_to_json x_0 |] : Js.Json.t)
+          (Obj.magic
+             [|
+               Ppx_deriving_json_runtime.Primitives.string_to_json "C";
+               a_to_json x_0;
+             |]
+            : Js.Json.t)
   
     let _ = c_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
@@ -775,9 +807,18 @@
     let rec recur_to_json =
       (fun x ->
          match x with
-         | A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
+         | A ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
+                |]
+               : Js.Json.t)
          | Fix x_0 ->
-             (Obj.magic [| string_to_json "Fix"; recur_to_json x_0 |]
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "Fix";
+                  recur_to_json x_0;
+                |]
                : Js.Json.t)
         : recur -> Js.Json.t)
   
@@ -842,9 +883,18 @@
     let rec polyrecur_to_json =
       (fun x ->
          match x with
-         | `A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
+         | `A ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
+                |]
+               : Js.Json.t)
          | `Fix x_0 ->
-             (Obj.magic [| string_to_json "Fix"; polyrecur_to_json x_0 |]
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "Fix";
+                  polyrecur_to_json x_0;
+                |]
                : Js.Json.t)
         : polyrecur -> Js.Json.t)
   
@@ -900,8 +950,19 @@
     let rec evar_to_json =
       (fun x ->
          match x with
-         | A -> (Obj.magic [| string_to_json "A" |] : Js.Json.t)
-         | B -> (Obj.magic [| string_to_json "b_aliased" |] : Js.Json.t)
+         | A ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
+                |]
+               : Js.Json.t)
+         | B ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json
+                    "b_aliased";
+                |]
+               : Js.Json.t)
         : evar -> Js.Json.t)
   
     let _ = evar_to_json
@@ -964,8 +1025,19 @@
     let rec epoly_to_json =
       (fun x ->
          match x with
-         | `a -> (Obj.magic [| string_to_json "A_aliased" |] : Js.Json.t)
-         | `b -> (Obj.magic [| string_to_json "b" |] : Js.Json.t)
+         | `a ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json
+                    "A_aliased";
+                |]
+               : Js.Json.t)
+         | `b ->
+             (Obj.magic
+                [|
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "b";
+                |]
+               : Js.Json.t)
         : epoly -> Js.Json.t)
   
     let _ = epoly_to_json
@@ -1019,9 +1091,19 @@
      fun x ->
       match x with
       | A x_0 ->
-          (Obj.magic [| string_to_json "A"; a_to_json x_0 |] : Js.Json.t)
+          (Obj.magic
+             [|
+               Ppx_deriving_json_runtime.Primitives.string_to_json "A";
+               a_to_json x_0;
+             |]
+            : Js.Json.t)
       | B x_0 ->
-          (Obj.magic [| string_to_json "B"; b_to_json x_0 |] : Js.Json.t)
+          (Obj.magic
+             [|
+               Ppx_deriving_json_runtime.Primitives.string_to_json "B";
+               b_to_json x_0;
+             |]
+            : Js.Json.t)
   
     let _ = p2_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
@@ -1147,7 +1229,7 @@
          | A { a = x_a } ->
              (Obj.magic
                 [|
-                  string_to_json "A";
+                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
                   (Obj.magic [%mel.obj { a = int_to_json x_a }] : Js.Json.t);
                 |]
                : Js.Json.t)

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -406,23 +406,14 @@
     let rec sum_to_json =
       (fun x ->
          match x with
-         | A ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
-                |]
-               : Js.Json.t)
+         | A -> (Obj.magic [| (Obj.magic "A" : Js.Json.t) |] : Js.Json.t)
          | B x_0 ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "B";
-                  int_to_json x_0;
-                |]
+             (Obj.magic [| (Obj.magic "B" : Js.Json.t); int_to_json x_0 |]
                : Js.Json.t)
          | C { name = x_name } ->
              (Obj.magic
                 [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "C";
+                  (Obj.magic "C" : Js.Json.t);
                   (Obj.magic [%mel.obj { name = string_to_json x_name }]
                     : Js.Json.t);
                 |]
@@ -481,7 +472,7 @@
          | S2 (x_0, x_1) ->
              (Obj.magic
                 [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "S2";
+                  (Obj.magic "S2" : Js.Json.t);
                   int_to_json x_0;
                   string_to_json x_1;
                 |]
@@ -543,12 +534,7 @@
     let rec other_to_json =
       (fun x ->
          match x with
-         | `C ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "C";
-                |]
-               : Js.Json.t)
+         | `C -> (Obj.magic [| (Obj.magic "C" : Js.Json.t) |] : Js.Json.t)
         : other -> Js.Json.t)
   
     let _ = other_to_json
@@ -611,18 +597,9 @@
     let rec poly_to_json =
       (fun x ->
          match x with
-         | `A ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
-                |]
-               : Js.Json.t)
+         | `A -> (Obj.magic [| (Obj.magic "A" : Js.Json.t) |] : Js.Json.t)
          | `B x_0 ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "B";
-                  int_to_json x_0;
-                |]
+             (Obj.magic [| (Obj.magic "B" : Js.Json.t); int_to_json x_0 |]
                : Js.Json.t)
          | #other as x -> other_to_json x
         : poly -> Js.Json.t)
@@ -688,7 +665,7 @@
          | `P2 (x_0, x_1) ->
              (Obj.magic
                 [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "P2";
+                  (Obj.magic "P2" : Js.Json.t);
                   int_to_json x_0;
                   string_to_json x_1;
                 |]
@@ -748,11 +725,7 @@
      fun x ->
       match x with
       | `C x_0 ->
-          (Obj.magic
-             [|
-               Ppx_deriving_json_runtime.Primitives.string_to_json "C";
-               a_to_json x_0;
-             |]
+          (Obj.magic [| (Obj.magic "C" : Js.Json.t); a_to_json x_0 |]
             : Js.Json.t)
   
     let _ = c_to_json
@@ -807,18 +780,10 @@
     let rec recur_to_json =
       (fun x ->
          match x with
-         | A ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
-                |]
-               : Js.Json.t)
+         | A -> (Obj.magic [| (Obj.magic "A" : Js.Json.t) |] : Js.Json.t)
          | Fix x_0 ->
              (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "Fix";
-                  recur_to_json x_0;
-                |]
+                [| (Obj.magic "Fix" : Js.Json.t); recur_to_json x_0 |]
                : Js.Json.t)
         : recur -> Js.Json.t)
   
@@ -883,18 +848,10 @@
     let rec polyrecur_to_json =
       (fun x ->
          match x with
-         | `A ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
-                |]
-               : Js.Json.t)
+         | `A -> (Obj.magic [| (Obj.magic "A" : Js.Json.t) |] : Js.Json.t)
          | `Fix x_0 ->
              (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "Fix";
-                  polyrecur_to_json x_0;
-                |]
+                [| (Obj.magic "Fix" : Js.Json.t); polyrecur_to_json x_0 |]
                : Js.Json.t)
         : polyrecur -> Js.Json.t)
   
@@ -950,18 +907,9 @@
     let rec evar_to_json =
       (fun x ->
          match x with
-         | A ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
-                |]
-               : Js.Json.t)
+         | A -> (Obj.magic [| (Obj.magic "A" : Js.Json.t) |] : Js.Json.t)
          | B ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json
-                    "b_aliased";
-                |]
+             (Obj.magic [| (Obj.magic "b_aliased" : Js.Json.t) |]
                : Js.Json.t)
         : evar -> Js.Json.t)
   
@@ -1026,18 +974,9 @@
       (fun x ->
          match x with
          | `a ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json
-                    "A_aliased";
-                |]
+             (Obj.magic [| (Obj.magic "A_aliased" : Js.Json.t) |]
                : Js.Json.t)
-         | `b ->
-             (Obj.magic
-                [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "b";
-                |]
-               : Js.Json.t)
+         | `b -> (Obj.magic [| (Obj.magic "b" : Js.Json.t) |] : Js.Json.t)
         : epoly -> Js.Json.t)
   
     let _ = epoly_to_json
@@ -1091,18 +1030,10 @@
      fun x ->
       match x with
       | A x_0 ->
-          (Obj.magic
-             [|
-               Ppx_deriving_json_runtime.Primitives.string_to_json "A";
-               a_to_json x_0;
-             |]
+          (Obj.magic [| (Obj.magic "A" : Js.Json.t); a_to_json x_0 |]
             : Js.Json.t)
       | B x_0 ->
-          (Obj.magic
-             [|
-               Ppx_deriving_json_runtime.Primitives.string_to_json "B";
-               b_to_json x_0;
-             |]
+          (Obj.magic [| (Obj.magic "B" : Js.Json.t); b_to_json x_0 |]
             : Js.Json.t)
   
     let _ = p2_to_json
@@ -1229,7 +1160,7 @@
          | A { a = x_a } ->
              (Obj.magic
                 [|
-                  Ppx_deriving_json_runtime.Primitives.string_to_json "A";
+                  (Obj.magic "A" : Js.Json.t);
                   (Obj.magic [%mel.obj { a = int_to_json x_a }] : Js.Json.t);
                 |]
                : Js.Json.t)

--- a/ppx/test/ppx_deriving_json_js_variants.e2e.t
+++ b/ppx/test/ppx_deriving_json_js_variants.e2e.t
@@ -21,9 +21,6 @@
   > let json = sum_to_json A
   > ' >> main.ml
 
+Can build without having to open Ppx_deriving_json_runtime.Primitives
+
   $ dune build @js
-  File "main.ml", line 2, characters 11-12:
-  2 | type sum = A [@@deriving json]
-                 ^
-  Error: Unbound value string_to_json
-  [1]

--- a/ppx/test/ppx_deriving_json_js_variants.e2e.t
+++ b/ppx/test/ppx_deriving_json_js_variants.e2e.t
@@ -1,0 +1,29 @@
+
+  $ echo '(lang dune 3.11) 
+  > (using melange 0.1)' > dune-project
+
+  $ echo '
+  > (library
+  >  (name lib)
+  >  (modes melange)
+  >  (modules main)
+  >  (flags :standard -w -37-69)
+  >  (preprocess (pps melange.ppx melange-json.ppx)))
+  > (melange.emit
+  >  (alias js)
+  >  (target output)
+  >  (modules)
+  >  (libraries lib)
+  >  (module_systems commonjs))' > dune
+
+  $ echo '
+  > type sum = A [@@deriving json]
+  > let json = sum_to_json A
+  > ' >> main.ml
+
+  $ dune build @js
+  File "main.ml", line 2, characters 11-12:
+  2 | type sum = A [@@deriving json]
+                 ^
+  Error: Unbound value string_to_json
+  [1]


### PR DESCRIPTION
Fixes #34.

The first commit adds a test that shows the error on JS side. The second commit fixes it.