### PR TITLE
Add back some variant tests

### DIFF
--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -46,6 +46,10 @@ let of_json_cases = [
   C ({|["P2", 42, "hello"]|}, poly2_of_json, poly2_to_json, (`P2 (42, "hello") : poly2));
   C ({|["Fix",["Fix",["Fix",["A"]]]]|}, recur_of_json, recur_to_json, (Fix (Fix (Fix A))));
   C ({|["Fix",["Fix",["Fix",["A"]]]]|}, polyrecur_of_json, polyrecur_to_json, (`Fix (`Fix (`Fix `A))));
+  C ({|["A"]|}, evar_of_json, evar_to_json, (A : evar));
+  C ({|["b_aliased"]|}, evar_of_json, evar_to_json, (B : evar)); (* variant B repr as "b_aliased" in JSON *)
+  C ({|["b"]|}, epoly_of_json, epoly_to_json, (`b : epoly));
+  C ({|["A_aliased"]|}, epoly_of_json, epoly_to_json, (`a : epoly)); (* polyvariant `a aliased to "A_aliased"*)
   C ({|{"my_name":"N","my_age":1}|}, record_aliased_of_json, record_aliased_to_json, {name="N"; age=1});
   C ({|{"my_name":"N"}|}, record_aliased_of_json, record_aliased_to_json, {name="N"; age=100});
   C ({|{}|}, record_opt_of_json, record_opt_to_json, {k=None});

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -67,6 +67,14 @@
   JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
   JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
   JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["b_aliased"]
+  JSON REPRINT: ["b_aliased"]
+  JSON    DATA: ["b"]
+  JSON REPRINT: ["b"]
+  JSON    DATA: ["A_aliased"]
+  JSON REPRINT: ["A_aliased"]
   JSON    DATA: {"my_name":"N","my_age":1}
   JSON REPRINT: {"my_name":"N","my_age":1}
   JSON    DATA: {"my_name":"N"}

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -57,6 +57,14 @@
   JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
   JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
   JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["b_aliased"]
+  JSON REPRINT: ["b_aliased"]
+  JSON    DATA: ["b"]
+  JSON REPRINT: ["b"]
+  JSON    DATA: ["A_aliased"]
+  JSON REPRINT: ["A_aliased"]
   JSON    DATA: {"my_name":"N","my_age":1}
   JSON REPRINT: {"my_name":"N","my_age":1}
   JSON    DATA: {"my_name":"N"}


### PR DESCRIPTION
The tests were removed in #26. @anmonteiro [suggested to keep them](https://github.com/melange-community/melange-json/pull/26/files#r1788636591) and I think it's worth it as they show how variants with `json.name` are encoded.

If we think otherwise, we can remove the type definitions that are used in these tests.