### PR TITLE
Fix bug on `either` error handling

### DIFF
--- a/src/Json_decode.ml
+++ b/src/Json_decode.ml
@@ -178,7 +178,7 @@ let oneOf decoders json =
     | [] ->
         let formattedErrors =
           "\n- "
-          ^ Js.Array.join ~sep:"\n- " (Array.of_list (List.rev errors))
+          ^ Js.Array.join ~sep:"\n- " (Array.of_list (List.rev_map error_to_string errors))
         in
         error
           ({j|All decoders given to oneOf failed. Here are all the errors: $formattedErrors\nAnd the JSON being decoded: |j}

--- a/src/__tests__/Json_decode_test.ml
+++ b/src/__tests__/Json_decode_test.ml
@@ -86,6 +86,12 @@ let () =
       test "single-character string" (fun () ->
           expect @@ string (Encode.char 'a') |> toEqual "a");
 
+      test "object as string" (fun () ->
+          try
+            let (_ : string) = string (Encode.jsonDict (Js.Dict.empty ())) in
+            fail "should throw"
+          with DecodeError Json_error "Expected string, got {}" -> pass);
+
       Test.throws string [ Bool; Float; Int; Null; Array; Object ]);
 
   describe "date" (fun () ->
@@ -708,6 +714,13 @@ let () =
           |> toEqual 2);
       test "int" (fun () ->
           expect @@ (either int (field "x" int)) (Encode.int 23) |> toEqual 23);
+
+     test "object as string in either" (fun () ->
+          try
+            let a = Encode.jsonDict (Js.Dict.empty ()) in
+            let (_ : string) = either string string a in
+            fail "should throw"
+          with DecodeError (Json_error "All decoders given to oneOf failed. Here are all the errors: \n- [object Object]\n- [object Object]\nAnd the JSON being decoded: {}") -> pass);
 
       Test.throws
         (either int (field "x" int))

--- a/src/__tests__/Json_decode_test.ml
+++ b/src/__tests__/Json_decode_test.ml
@@ -720,7 +720,7 @@ let () =
             let a = Encode.jsonDict (Js.Dict.empty ()) in
             let (_ : string) = either string string a in
             fail "should throw"
-          with DecodeError (Json_error "All decoders given to oneOf failed. Here are all the errors: \n- [object Object]\n- [object Object]\nAnd the JSON being decoded: {}") -> pass);
+          with DecodeError (Json_error "All decoders given to oneOf failed. Here are all the errors: \n- Expected string, got {}\n- Expected string, got {}\nAnd the JSON being decoded: {}") -> pass);
 
       Test.throws
         (either int (field "x" int))


### PR DESCRIPTION
First commit adds a test to showcase the issue (found while trying to fix melange-atdgen-codec-runtime for the latest version of the library). 

Second commit adds the fix.