### PR TITLE
switch to ocamlformat 0.27.0 and format everything.

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,4 @@
 break-infix=fit-or-vertical
 margin=74
 parens-tuple=multi-line-only
+version=0.27.0


### PR DESCRIPTION
There are quite large difference in the formatting, but I think that it worth it.
Conflict should be easy to solve by rewriting history so that the formatting happened earlier.

The version I picked is the latest one that is used by the CI.