### PR TITLE
Make classify/declassify recursive over the full JSON tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- **[breaking]** `classify` now fully traverses the JSON tree recursively,
+  returning a `Classify.t` where `\`List` and `\`Assoc` elements are
+  themselves `Classify.t` rather than raw `Js.Json.t`. `declassify` is
+  similarly recursive, accepting `Classify.t` and converting back to
+  `Js.Json.t`.
 - Support `Ptype_open`, e.g. `type u = X.(x) [@@deriving json]`
   ([#60](https://github.com/melange-community/melange-json/pull/60))
 

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -6,6 +6,7 @@
   > (library
   >  (name lib)
   >  (modes melange)
+  >  (libraries melange-json)
   >  (modules example example_json_string main)
   >  (flags :standard -w -20-37-69 -open Melange_json.Primitives)
   >  (preprocess (pps melange.ppx melange-json.ppx)))

--- a/ppx/test/ppx_deriving_json_js_variants.e2e.t
+++ b/ppx/test/ppx_deriving_json_js_variants.e2e.t
@@ -7,6 +7,7 @@
   >  (name lib)
   >  (modes melange)
   >  (modules main)
+  >  (libraries melange-json)
   >  (flags :standard -w -20-37-69)
   >  (preprocess (pps melange.ppx melange-json.ppx)))
   > (melange.emit

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -5,6 +5,7 @@
   $ echo '
   > (executable
   >   (name main)
+  >   (libraries melange-json)
   >   (flags :standard -w -37-69 -open Melange_json.Primitives)
   >   (preprocess (pps melange-json-native.ppx)))' > dune
 

--- a/ppx/test/run.sh
+++ b/ppx/test/run.sh
@@ -13,6 +13,7 @@ echo '
  (name lib)
  (modes melange)
  (modules main_js)
+ (libraries melange-json)
  (flags :standard -w -20-37-69 -open Melange_json.Primitives)
  (preprocess (pps melange.ppx melange-json.ppx)))
 (melange.emit

--- a/src/__tests__/Json_test.ml
+++ b/src/__tests__/Json_test.ml
@@ -32,4 +32,101 @@ let () =
             pass));
 
   test "stringify" (fun () ->
-      expect @@ stringify Encode.null |> toEqual "null")
+      expect @@ stringify Encode.null |> toEqual "null");
+
+  describe "classify" (fun () ->
+      test "null" (fun () ->
+          expect @@ classify Encode.null |> toEqual `Null);
+
+      test "bool" (fun () ->
+          expect @@ classify (Encode.bool true) |> toEqual (`Bool true));
+
+      test "int" (fun () ->
+          expect @@ classify (Encode.int 42) |> toEqual (`Int 42));
+
+      test "float" (fun () ->
+          expect @@ classify (Encode.float 1.5) |> toEqual (`Float 1.5));
+
+      test "string" (fun () ->
+          expect @@ classify (Encode.string "hi")
+          |> toEqual (`String "hi"));
+
+      test "list - recursively classifies elements" (fun () ->
+          let json =
+            Encode.jsonArray
+              [| Encode.int 1; Encode.string "a"; Encode.null |]
+          in
+          expect @@ classify json
+          |> toEqual (`List [ `Int 1; `String "a"; `Null ]));
+
+      test "assoc - recursively classifies values" (fun () ->
+          let json =
+            Encode.object_ [ "n", Encode.null; "x", Encode.int 7 ]
+          in
+          expect @@ classify json
+          |> toEqual (`Assoc [ "n", `Null; "x", `Int 7 ]));
+
+      test "nested - fully traverses tree" (fun () ->
+          let json =
+            Encode.object_
+              [
+                ( "items",
+                  Encode.jsonArray
+                    [| Encode.bool false; Encode.float 3.14 |] );
+              ]
+          in
+          expect @@ classify json
+          |> toEqual
+               (`Assoc [ "items", `List [ `Bool false; `Float 3.14 ] ])));
+
+  describe "declassify" (fun () ->
+      test "null" (fun () ->
+          expect @@ declassify `Null |> toEqual Encode.null);
+
+      test "bool" (fun () ->
+          expect @@ declassify (`Bool true) |> toEqual (Encode.bool true));
+
+      test "int" (fun () ->
+          expect @@ declassify (`Int 42) |> toEqual (Encode.int 42));
+
+      test "float" (fun () ->
+          expect @@ declassify (`Float 1.5) |> toEqual (Encode.float 1.5));
+
+      test "string" (fun () ->
+          expect @@ declassify (`String "hi")
+          |> toEqual (Encode.string "hi"));
+
+      test "list - recursively declassifies elements" (fun () ->
+          expect
+          @@ declassify (`List [ `Int 1; `String "a"; `Null ])
+          |> toEqual
+               (Encode.jsonArray
+                  [| Encode.int 1; Encode.string "a"; Encode.null |]));
+
+      test "assoc - recursively declassifies values" (fun () ->
+          expect
+          @@ declassify (`Assoc [ ("n", `Null); ("x", `Int 7) ])
+          |> toEqual (Encode.object_ [ ("n", Encode.null); ("x", Encode.int 7) ]));
+
+      test "nested - fully traverses tree" (fun () ->
+          expect
+          @@ declassify
+               (`Assoc [ ("items", `List [ `Bool false; `Float 3.14 ]) ])
+          |> toEqual
+               (Encode.object_
+                  [
+                    ( "items",
+                      Encode.jsonArray
+                        [| Encode.bool false; Encode.float 3.14 |] );
+                  ]));
+
+      test "roundtrip classify/declassify" (fun () ->
+          let json =
+            Encode.object_
+              [
+                ( "items",
+                  Encode.jsonArray
+                    [| Encode.bool false; Encode.float 3.14 |] );
+              ]
+          in
+          expect @@ declassify (classify json) |> toEqual json))

--- a/src/classify.ml
+++ b/src/classify.ml
@@ -1,16 +1,15 @@
 module J = Js.Json
 
-type t = J.t
+type t =
+  [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of t list
+  | `Assoc of (string * t) list ]
 
-let classify :
-    t ->
-    [ `Null
-    | `String of string
-    | `Float of float
-    | `Int of int
-    | `Bool of bool
-    | `List of t list
-    | `Assoc of (string * t) list ] =
+let rec classify : J.t -> t =
  fun json ->
   if (Obj.magic json : 'a Js.null) == Js.null then `Null
   else
@@ -24,26 +23,22 @@ let classify :
     | "boolean" -> `Bool (Obj.magic json : bool)
     | "object" ->
         if Js.Array.isArray json then
-          let xs = Array.to_list (Obj.magic json : t array) in
-          `List xs
+          let xs = Array.to_list (Obj.magic json : J.t array) in
+          `List (List.map classify xs)
         else
-          let xs = Js.Dict.entries (Obj.magic json : t Js.Dict.t) in
-          `Assoc (Array.to_list xs)
+          let xs = Js.Dict.entries (Obj.magic json : J.t Js.Dict.t) in
+          `Assoc
+            (Array.to_list (Array.map (fun (k, v) -> k, classify v) xs))
     | typ -> failwith ("unknown JSON value type: " ^ typ)
 
-let declassify :
-    [ `Null
-    | `String of string
-    | `Float of float
-    | `Int of int
-    | `Bool of bool
-    | `List of t list
-    | `Assoc of (string * t) list ] ->
-    t = function
+let rec declassify : t -> J.t = function
   | `Null -> J.null
   | `String str -> J.string str
   | `Float f -> J.number f
   | `Int i -> J.number (Js.Int.toFloat i)
   | `Bool b -> J.boolean b
-  | `List li -> J.array (Array.of_list li)
-  | `Assoc assoc -> J.object_ (Js.Dict.fromList assoc)
+  | `List li -> J.array (Array.of_list (List.map declassify li))
+  | `Assoc assoc ->
+      J.object_
+        (Js.Dict.fromList
+           (List.map (fun (k, v) -> k, declassify v) assoc))

--- a/src/errors.ml
+++ b/src/errors.ml
@@ -32,13 +32,12 @@ let show_json_type json =
 
 let show_json_error ?depth ?width json =
   with_buffer (fun emit ->
-      let rec loop ?depth json =
-        let json = Classify.classify json in
+      let rec loop ?depth classified =
         let depth = Option.map (fun i -> i - 1) depth in
         match depth with
         | Some 0 -> emit "_"
         | _ -> (
-            match json with
+            match classified with
             | `Assoc assoc ->
                 emit "{";
                 iteri_last
@@ -88,7 +87,7 @@ let show_json_error ?depth ?width json =
                     emit {|"|}))
       in
 
-      (loop ?depth:(Option.map (fun i -> i + 1) depth)) json)
+      (loop ?depth:(Option.map (fun i -> i + 1) depth)) (Classify.classify json))
 
 let of_json_msg_error msg = raise (Of_json_error (Json_error msg))
 

--- a/src/melange_json.mli
+++ b/src/melange_json.mli
@@ -416,24 +416,10 @@ val parse : string -> json option [@@deprecated "Use `of_string` instead"]
 val parseOrRaise : string -> json [@@deprecated "Use `of_string` instead"]
 val stringify : json -> string [@@deprecated "Use `to_string` instead"]
 
-val classify :
-  json ->
-  [ `Assoc of (string * json) list
-  | `Bool of bool
-  | `Float of float
-  | `Int of int
-  | `List of json list
-  | `Null
-  | `String of string ]
-(** Classify a JSON value into a variant type. *)
+val classify : json -> Classify.t
+(** Classify a JSON value into a variant type, recursively. *)
 
 val declassify :
-  [ `Assoc of (string * json) list
-  | `Bool of bool
-  | `Float of float
-  | `Int of int
-  | `List of json list
-  | `Null
-  | `String of string ] ->
+  Classify.t ->
   json
 (** Declassify a variant type into a JSON value. *)

--- a/src/native/classify.ml
+++ b/src/native/classify.ml
@@ -1,23 +1,6 @@
-type t = Yojson.Basic.t
+(** Classify isn't needed for native, it's here to support the universal
+    approach of the library. In the end, it classify Yojson.Basic.t to
+    Yojson.Basic.t *)
 
-let classify :
-    t ->
-    [ `Null
-    | `String of string
-    | `Float of float
-    | `Int of int
-    | `Bool of bool
-    | `List of t list
-    | `Assoc of (string * t) list ] =
- fun x -> x
-
-let declassify :
-    [ `Null
-    | `String of string
-    | `Float of float
-    | `Int of int
-    | `Bool of bool
-    | `List of t list
-    | `Assoc of (string * t) list ] ->
-    t =
- fun x -> x
+let classify : Yojson.Basic.t -> Yojson.Basic.t = fun x -> x
+let declassify : Yojson.Basic.t -> Yojson.Basic.t = fun x -> x


### PR DESCRIPTION
## Summary

- `Classify.classify` now returns Classify.t, a recursive type where `List and `Assoc children are themselves Classify.t — a single call fully traverses the JSON tree instead of leaving nested values as raw Js.Json.t.

- `Classify.declassify` is the symmetric inverse: it now accepts Classify.t and recursively converts back to Js.Json.t.
errors.ml updated to work on the already-classified tree rather than re-calling classify at each level.

# ⚠️ Breaking change
Code that matches on the output of classify and expects `List of Js.Json.t list` or `Assoc of (string * Js.Json.t) list` must be updated to use `Classify.t instead`.

@andreypopp Can we have something like this?