### PR TITLE
Add missing doc on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,21 @@ val of_json : Js.Json.t -> t
 val to_json : t -> Js.Json.t
 ```
 
+### Primitives semantics
+
+The following table summarizes the correspondence between OCaml types and JSON values for the primitives:
+
+| OCaml type        | JSON value | Sample JSON value                                                   |
+| ----------------- | ---------- | ------------------------------------------------------------------- |
+| `int`, `float`    | Number     | `1.23`                                                              |
+| `int64`           | String     | `"1234567890"`                                                      |
+| `bool`            | Boolean    | `true`                                                              |
+| `string`          | String     | `"foo"`                                                             |
+| `list`, `array`   | Array      | `[1, 2, 3]`                                                         |
+| `'a option`       | Null or 'a | `string option` is `null` or `"foo"`; `int` option is `null` or `1` |
+| `unit`            | Null       | `null`                                                              |
+| `('a, 'b) result` | Array      | `(int, string) result` is `["Ok", 1]` or `["Error", "error"]`       |
+
 #### Generating JSON converters from type expressions
 
 You can also generate JSON converters for a type expression using the `to_json`


### PR DESCRIPTION
## Summary

- Adds a **Primitives semantics** section to the README documenting how OCaml primitive types map to JSON values, including sample JSON values for each
- Restricts the table to types with built-in runtime support (`int`, `float`, `int64`, `bool`, `string`, `list`/`array`, `'a option`, `unit`, `('a, 'b) result`)