### PR TITLE
ppx/test: cover encode behavior for @drop_default variants

### DIFF
--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -22,6 +22,10 @@ type ('a, 'b) p2 = A of 'a | B of 'b [@@deriving json]
 type allow_extra_fields = {a: int} [@@deriving json] [@@json.allow_extra_fields]
 type allow_extra_fields2 = A of {a: int} [@json.allow_extra_fields] [@@deriving json]
 type drop_default_option = { a: int; b_opt: int option; [@option] [@json.drop_default] } [@@deriving json]
+let equal_int = Int.equal
+type drop_default_int = { dd_a: int; dd_b: int [@json.default 0] [@json.drop_default] } [@@deriving json]
+type drop_default_expr = { dde_a: int; dde_b: int [@json.default 0] [@json.drop_default Int.equal] } [@@deriving json]
+type drop_default_if_json_eq = { ddj_a: int; ddj_b: int [@json.default 0] [@json.drop_default_if_json_equal] } [@@deriving json]
 type array_list = { a: int array; b: int list} [@@deriving json]
 type json = Melange_json.t
 type of_json = C : string * (json -> 'a) * ('a -> json) * 'a -> of_json
@@ -74,6 +78,12 @@ let of_json_cases = [
   C ({|["A",{"a":1,"b":2}]|}, allow_extra_fields2_of_json, allow_extra_fields2_to_json, A {a=1});
   C ({|{"a":1}|}, drop_default_option_of_json, drop_default_option_to_json, {a=1; b_opt=None});
   C ({|{"a":1,"b_opt":2}|}, drop_default_option_of_json, drop_default_option_to_json, {a=1; b_opt=Some 2});
+  C ({|{"dd_a":1}|}, drop_default_int_of_json, drop_default_int_to_json, {dd_a=1; dd_b=0});
+  C ({|{"dd_a":1,"dd_b":5}|}, drop_default_int_of_json, drop_default_int_to_json, {dd_a=1; dd_b=5});
+  C ({|{"dde_a":1}|}, drop_default_expr_of_json, drop_default_expr_to_json, {dde_a=1; dde_b=0});
+  C ({|{"dde_a":1,"dde_b":5}|}, drop_default_expr_of_json, drop_default_expr_to_json, {dde_a=1; dde_b=5});
+  C ({|{"ddj_a":1}|}, drop_default_if_json_eq_of_json, drop_default_if_json_eq_to_json, {ddj_a=1; ddj_b=0});
+  C ({|{"ddj_a":1,"ddj_b":5}|}, drop_default_if_json_eq_of_json, drop_default_if_json_eq_to_json, {ddj_a=1; ddj_b=5});
   C ({|{"a":[1],"b":[2]}|}, array_list_of_json, array_list_to_json, {a=[|1|]; b=[2]});
   C ({|["Circle", 5.0]|}, shape_of_json, shape_to_json, Circle 5.0);
   C ({|["Rectangle", 10.0, 20.0]|}, shape_of_json, shape_to_json, Rectangle (10.0, 20.0));

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -26,6 +26,11 @@ let equal_int = Int.equal
 type drop_default_int = { dd_a: int; dd_b: int [@json.default 0] [@json.drop_default] } [@@deriving json]
 type drop_default_expr = { dde_a: int; dde_b: int [@json.default 0] [@json.drop_default Int.equal] } [@@deriving json]
 type drop_default_if_json_eq = { ddj_a: int; ddj_b: int [@json.default 0] [@json.drop_default_if_json_equal] } [@@deriving json]
+type inner_with_option_field = { foo: int option [@option] [@json.drop_default] } [@@deriving json]
+let empty_inner_with_option_field : inner_with_option_field = { foo = None }
+type outer_default_record_with_option = {
+  inner: inner_with_option_field; [@json.default empty_inner_with_option_field]
+} [@@deriving json]
 type array_list = { a: int array; b: int list} [@@deriving json]
 type json = Melange_json.t
 type of_json = C : string * (json -> 'a) * ('a -> json) * 'a -> of_json
@@ -84,6 +89,9 @@ let of_json_cases = [
   C ({|{"dde_a":1,"dde_b":5}|}, drop_default_expr_of_json, drop_default_expr_to_json, {dde_a=1; dde_b=5});
   C ({|{"ddj_a":1}|}, drop_default_if_json_eq_of_json, drop_default_if_json_eq_to_json, {ddj_a=1; ddj_b=0});
   C ({|{"ddj_a":1,"ddj_b":5}|}, drop_default_if_json_eq_of_json, drop_default_if_json_eq_to_json, {ddj_a=1; ddj_b=5});
+  C ({|{"inner":{}}|}, outer_default_record_with_option_of_json, outer_default_record_with_option_to_json, {inner = {foo = None}});
+  C ({|{"inner":{"foo":5}}|}, outer_default_record_with_option_of_json, outer_default_record_with_option_to_json, {inner = {foo = Some 5}});
+  C ({|{}|}, outer_default_record_with_option_of_json, outer_default_record_with_option_to_json, {inner = empty_inner_with_option_field});
   C ({|{"a":[1],"b":[2]}|}, array_list_of_json, array_list_to_json, {a=[|1|]; b=[2]});
   C ({|["Circle", 5.0]|}, shape_of_json, shape_to_json, Circle 5.0);
   C ({|["Rectangle", 10.0, 20.0]|}, shape_of_json, shape_to_json, Rectangle (10.0, 20.0));

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -106,6 +106,18 @@
   JSON REPRINT: {"a":1}
   JSON    DATA: {"a":1,"b_opt":2}
   JSON REPRINT: {"a":1,"b_opt":2}
+  JSON    DATA: {"dd_a":1}
+  JSON REPRINT: {"dd_a":1}
+  JSON    DATA: {"dd_a":1,"dd_b":5}
+  JSON REPRINT: {"dd_a":1,"dd_b":5}
+  JSON    DATA: {"dde_a":1}
+  JSON REPRINT: {"dde_a":1}
+  JSON    DATA: {"dde_a":1,"dde_b":5}
+  JSON REPRINT: {"dde_a":1,"dde_b":5}
+  JSON    DATA: {"ddj_a":1}
+  JSON REPRINT: {"ddj_a":1}
+  JSON    DATA: {"ddj_a":1,"ddj_b":5}
+  JSON REPRINT: {"ddj_a":1,"ddj_b":5}
   JSON    DATA: {"a":[1],"b":[2]}
   JSON REPRINT: {"a":[1],"b":[2]}
   JSON    DATA: ["Circle", 5.0]

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -118,6 +118,12 @@
   JSON REPRINT: {"ddj_a":1}
   JSON    DATA: {"ddj_a":1,"ddj_b":5}
   JSON REPRINT: {"ddj_a":1,"ddj_b":5}
+  JSON    DATA: {"inner":{}}
+  JSON REPRINT: {"inner":{}}
+  JSON    DATA: {"inner":{"foo":5}}
+  JSON REPRINT: {"inner":{"foo":5}}
+  JSON    DATA: {}
+  JSON REPRINT: {"inner":{}}
   JSON    DATA: {"a":[1],"b":[2]}
   JSON REPRINT: {"a":[1],"b":[2]}
   JSON    DATA: ["Circle", 5.0]

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -95,6 +95,18 @@
   JSON REPRINT: {"a":1}
   JSON    DATA: {"a":1,"b_opt":2}
   JSON REPRINT: {"a":1,"b_opt":2}
+  JSON    DATA: {"dd_a":1}
+  JSON REPRINT: {"dd_a":1}
+  JSON    DATA: {"dd_a":1,"dd_b":5}
+  JSON REPRINT: {"dd_a":1,"dd_b":5}
+  JSON    DATA: {"dde_a":1}
+  JSON REPRINT: {"dde_a":1}
+  JSON    DATA: {"dde_a":1,"dde_b":5}
+  JSON REPRINT: {"dde_a":1,"dde_b":5}
+  JSON    DATA: {"ddj_a":1}
+  JSON REPRINT: {"ddj_a":1}
+  JSON    DATA: {"ddj_a":1,"ddj_b":5}
+  JSON REPRINT: {"ddj_a":1,"ddj_b":5}
   JSON    DATA: {"a":[1],"b":[2]}
   JSON REPRINT: {"a":[1],"b":[2]}
   JSON    DATA: ["Circle", 5.0]

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -107,6 +107,12 @@
   JSON REPRINT: {"ddj_a":1}
   JSON    DATA: {"ddj_a":1,"ddj_b":5}
   JSON REPRINT: {"ddj_a":1,"ddj_b":5}
+  JSON    DATA: {"inner":{}}
+  JSON REPRINT: {"inner":{}}
+  JSON    DATA: {"inner":{"foo":5}}
+  JSON REPRINT: {"inner":{"foo":5}}
+  JSON    DATA: {}
+  JSON REPRINT: {"inner":{}}
   JSON    DATA: {"a":[1],"b":[2]}
   JSON REPRINT: {"a":[1],"b":[2]}
   JSON    DATA: ["Circle", 5.0]


### PR DESCRIPTION
Existing e2e runtime tests only exercised the `[@option] + [@json.drop_default]` combination via `drop_default_option`. The other three drop-default shapes had only PPX-generation coverage in `ppx_deriving_json_js.t` / `ppx_deriving_json_native.t`, but no runtime assertion that the encoder actually drops the field.

This PR adds runtime cases for the three remaining shapes so the encode behavior (drop when value matches default vs. include otherwise) is visible in the cram output:

- `[@json.default E] [@json.drop_default]` (flag form, non-option default; uses `equal_<type>` in scope)
- `[@json.default E] [@json.drop_default expr]` (custom comparator form)
- `[@json.default E] [@json.drop_default_if_json_equal]`

Each new type contributes two cases: value matching the default (field dropped) and value differing (field included). Behavior is identical between native and JS backends.

This PR was motivated by a bug in ppx_deriving_jsonschema, which was struggling to handle an absent value marked with `[@option] [@drop_default]`, as such values are serialized to `undefined` by melange json. It seems like a useful information to capture in the tests. Unfortunately it is not very explicit.
