### PR TITLE
Fix error message for @@compact_variants

### DIFF
--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -107,7 +107,8 @@ module Of_json = struct
       [%e ensure_json_object ~loc x];
       [%e build_record ~loc derive t.rcd_fields x Fun.id]]
 
-  let derive_of_variant _derive t ~allow_any_constr ?td body x =
+  let derive_of_variant ?(is_compact_variants = false) _derive t
+      ~allow_any_constr body x =
     let loc = t.vrt_loc in
     let not_array_error =
       match allow_any_constr with
@@ -118,7 +119,7 @@ module Of_json = struct
               "expected a non empty JSON array"]
     in
     let string_branch =
-      if Option.fold ~none:false ~some:is_compact_variants td then
+      if is_compact_variants then
         [%expr
           if Stdlib.( = ) (Js.typeof [%e x]) "string" then (
             let array = (Obj.magic [||] : Js.Json.t array) in
@@ -170,32 +171,34 @@ module Of_json = struct
       in
       ({ tag = tag_s; payload } : Melange_json.unknown_variant_case)]
 
-  let derive_of_variant_case ?td derive make c ~allow_any_constr next =
-    let compact = Option.fold ~none:false ~some:is_compact_variants td in
+  let derive_of_variant_case ?(is_compact_variants = false) derive make c
+      ~allow_any_constr next =
     let _ = derive in
     let _ = allow_any_constr in
     match c with
-    | Vcs_tuple (n, t) when vcs_attr_json_catch_all t.tpl_ctx ->
+    | Vcs_tuple (n, t) when vcs_attr_json_catch_all t.tpl_ctx -> (
         let loc = n.loc in
-        (match t.tpl_types with
-         | [ _ ] -> make (Some (build_unknown_variant_case_record ~loc))
-         | _ ->
-             Location.raise_errorf ~loc
-               "[@json.catch_all] requires exactly one argument: a record \
-                type with fields `tag : string` and \
-                `payload : Melange_json.t list option` (typically \
-                [Melange_json.unknown_variant_case])")
-    | Vcs_record (_n, t) when vcs_attr_json_catch_all t.rcd_ctx ->
+        match t.tpl_types with
+        | [ _ ] -> make (Some (build_unknown_variant_case_record ~loc))
+        | _ ->
+            Location.raise_errorf ~loc
+              "[@json.catch_all] requires exactly one argument: a record \
+               type with fields `tag : string` and `payload : \
+               Melange_json.t list option` (typically \
+               [Melange_json.unknown_variant_case])")
+    | Vcs_record (_n, t) when vcs_attr_json_catch_all t.rcd_ctx -> (
         let loc = t.rcd_loc in
-        (match t.rcd_fields with
-         | [ { pld_name = { txt = "tag"; _ }; _ };
-             { pld_name = { txt = "payload"; _ }; _ } ] ->
-             make (Some (build_unknown_variant_case_record ~loc))
-         | _ ->
-             Location.raise_errorf ~loc
-               "[@json.catch_all] inline record must have exactly two \
-                fields named `tag` and `payload` (in that order), with \
-                types `string` and `Melange_json.t list option`")
+        match t.rcd_fields with
+        | [
+         { pld_name = { txt = "tag"; _ }; _ };
+         { pld_name = { txt = "payload"; _ }; _ };
+        ] ->
+            make (Some (build_unknown_variant_case_record ~loc))
+        | _ ->
+            Location.raise_errorf ~loc
+              "[@json.catch_all] inline record must have exactly two \
+               fields named `tag` and `payload` (in that order), with \
+               types `string` and `Melange_json.t list option`")
     | Vcs_record (n, r) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name r.rcd_ctx) in
@@ -216,7 +219,7 @@ module Of_json = struct
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
-        if compact && arity = 0 then
+        if is_compact_variants && arity = 0 then
           [%expr
             if Stdlib.( = ) tag [%e estring ~loc:n.loc n.txt] then
               [%e make None]
@@ -286,8 +289,7 @@ module To_json = struct
     let record = pexp_record ~loc fs None in
     as_json ~loc [%expr [%mel.obj [%e record]]]
 
-  let derive_of_variant_case ?td derive c es =
-    let compact = Option.fold ~none:false ~some:is_compact_variants td in
+  let derive_of_variant_case ?(is_compact_variants = false) derive c es =
     match c with
     | Vcs_tuple (n, t) when vcs_attr_json_catch_all t.tpl_ctx -> (
         let loc = n.loc in
@@ -303,37 +305,45 @@ module To_json = struct
                   in
                   let rest =
                     Stdlib.List.map
-                      (fun (j : Melange_json.t) -> (Obj.magic j : Js.Json.t))
+                      (fun (j : Melange_json.t) ->
+                        (Obj.magic j : Js.Json.t))
                       xs
                   in
                   (Obj.magic
-                     (Stdlib.Array.of_list (head :: rest) : Js.Json.t array)
+                     (Stdlib.Array.of_list (head :: rest)
+                       : Js.Json.t array)
                     : Js.Json.t)]
         | _ ->
             Location.raise_errorf ~loc
               "[@json.catch_all] requires exactly one argument: a record \
-               type with fields `tag : string` and \
-               `payload : Melange_json.t list option` (typically \
+               type with fields `tag : string` and `payload : \
+               Melange_json.t list option` (typically \
                [Melange_json.unknown_variant_case])")
     | Vcs_record (_n, t) when vcs_attr_json_catch_all t.rcd_ctx -> (
         let loc = t.rcd_loc in
         match t.rcd_fields, es with
-        | ( [ { pld_name = { txt = "tag"; _ }; _ };
-              { pld_name = { txt = "payload"; _ }; _ } ],
+        | ( [
+              { pld_name = { txt = "tag"; _ }; _ };
+              { pld_name = { txt = "payload"; _ }; _ };
+            ],
             [ tag_e; payload_e ] ) ->
             [%expr
               match [%e payload_e] with
               | Stdlib.Option.None ->
                   (Obj.magic ([%e tag_e] : string) : Js.Json.t)
               | Stdlib.Option.Some xs ->
-                  let head = (Obj.magic ([%e tag_e] : string) : Js.Json.t) in
+                  let head =
+                    (Obj.magic ([%e tag_e] : string) : Js.Json.t)
+                  in
                   let rest =
                     Stdlib.List.map
-                      (fun (j : Melange_json.t) -> (Obj.magic j : Js.Json.t))
+                      (fun (j : Melange_json.t) ->
+                        (Obj.magic j : Js.Json.t))
                       xs
                   in
                   (Obj.magic
-                     (Stdlib.Array.of_list (head :: rest) : Js.Json.t array)
+                     (Stdlib.Array.of_list (head :: rest)
+                       : Js.Json.t array)
                     : Js.Json.t)]
         | _ ->
             Location.raise_errorf ~loc
@@ -359,7 +369,7 @@ module To_json = struct
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
-        if compact && arity = 0 then
+        if is_compact_variants && arity = 0 then
           as_json ~loc (estring ~loc:n.loc n.txt)
         else
           let tag =

--- a/ppx/native/common/ppx_deriving_json_common.ml
+++ b/ppx/native/common/ppx_deriving_json_common.ml
@@ -101,16 +101,6 @@ let ld_attr_json_drop_default_if_json_equal =
     (Attribute.declare_flag "json.drop_default_if_json_equal"
        Attribute.Context.label_declaration)
 
-let td_attr_json_compact_variants =
-  Attribute.get
-    (Attribute.declare "json.compact_variants"
-       Attribute.Context.type_declaration
-       Ast_pattern.(pstr nil)
-       ())
-
-let is_compact_variants td =
-  Option.is_some (td_attr_json_compact_variants td)
-
 let ld_attr_default ld =
   match ld_attr_json_default ld with
   | Some e -> Some e

--- a/ppx/native/common/ppx_deriving_tools.ml
+++ b/ppx/native/common/ppx_deriving_tools.ml
@@ -23,6 +23,16 @@ module Lid = struct
              ~init:(Lident hd) tl)
 end
 
+let td_attr_json_compact_variants =
+  Attribute.get
+    (Attribute.declare "json.compact_variants"
+       Attribute.Context.type_declaration
+       Ast_pattern.(pstr nil)
+       ())
+
+let is_compact_variants td =
+  Option.is_some (td_attr_json_compact_variants td)
+
 let not_supported ~loc what =
   Location.raise_errorf ~loc "%s are not supported" what
 
@@ -248,7 +258,11 @@ module Schema = struct
           not_supported "variant types" ~loc
 
       method derive_of_polyvariant :
-          ?td:type_declaration -> core_type -> row_field list -> expression -> expression =
+          ?td:type_declaration ->
+          core_type ->
+          row_field list ->
+          expression ->
+          expression =
         fun ?td:_ t _ _ ->
           let loc = t.ptyp_loc in
           not_supported "polyvariant types" ~loc
@@ -322,8 +336,8 @@ module Schema = struct
         let x = [%expr x] in
         let expr =
           match repr_type_declaration td with
-          | `Ptype_core_type ({ ptyp_desc = Ptyp_variant (fs, _, _); _ } as t)
-            ->
+          | `Ptype_core_type
+              ({ ptyp_desc = Ptyp_variant (fs, _, _); _ } as t) ->
               self#derive_of_polyvariant ~td t fs x
           | `Ptype_core_type t -> self#derive_of_core_type t x
           | `Ptype_variant ctors -> self#derive_of_variant td ctors x
@@ -389,11 +403,12 @@ let rec get_variant_names ~loc c =
           List.concat_map fields ~f:(get_variant_names ~loc)
       | _ -> [])
 
-let get_constructor_names cs =
+let get_constructor_names ?(compact = false) cs =
   List.map cs ~f:(fun c ->
       let name = c.pcd_name in
       match c.pcd_args with
       | Pcstr_record _fs -> Printf.sprintf {|["%s", { _ }]|} name.txt
+      | Pcstr_tuple [] when compact -> Printf.sprintf {|"%s"|} name.txt
       | Pcstr_tuple li ->
           Printf.sprintf {|["%s"%s]|} name.txt
             (li |> List.map ~f:(fun _ -> ", _") |> String.concat ~sep:""))
@@ -439,15 +454,15 @@ module Conv = struct
   let deriving_of ~name ~of_t ~is_allow_any_constr ~derive_of_tuple
       ~derive_of_record
       ~(derive_of_variant :
+         ?is_compact_variants:bool ->
          derive_of_core_type ->
          variant ->
          allow_any_constr:(expression -> expression) option ->
-         ?td:type_declaration ->
          expression ->
          expression ->
          expression)
       ~(derive_of_variant_case :
-         ?td:type_declaration ->
+         ?is_compact_variants:bool ->
          derive_of_core_type ->
          (expression option -> expression) ->
          variant_case ->
@@ -483,6 +498,7 @@ module Conv = struct
              ~f:(fun cs -> not (is_allow_any_constr (Vcs_ctx_variant cs)))
              cs
          in
+         let compact = is_compact_variants td in
          let body, cases =
            List.fold_left cs
              ~init:
@@ -491,7 +507,7 @@ module Conv = struct
                | None ->
                    let error_message =
                      Printf.sprintf "expected %s"
-                       (get_constructor_names cs
+                       (get_constructor_names ~compact cs
                        |> String.concat ~sep:" or ")
                    in
                    ( [%expr
@@ -513,8 +529,9 @@ module Conv = struct
                      Vcs_record (n, t)
                    in
                    let next =
-                     derive_of_variant_case ~td self#derive_of_core_type
-                       (make n) t ~allow_any_constr next
+                     derive_of_variant_case ~is_compact_variants:compact
+                       self#derive_of_core_type (make n) t
+                       ~allow_any_constr next
                    in
                    next, t :: cases
                | Pcstr_tuple ts ->
@@ -525,8 +542,9 @@ module Conv = struct
                      Vcs_tuple (n, t)
                    in
                    let next =
-                     derive_of_variant_case ~td self#derive_of_core_type
-                       (make n) case ~allow_any_constr next
+                     derive_of_variant_case ~is_compact_variants:compact
+                       self#derive_of_core_type (make n) case
+                       ~allow_any_constr next
                    in
                    next, case :: cases)
          in
@@ -537,10 +555,10 @@ module Conv = struct
              vrt_ctx = Vrt_ctx_variant td;
            }
          in
-         derive_of_variant self#derive_of_core_type t ~allow_any_constr
-           ~td body x
+         derive_of_variant ~is_compact_variants:compact
+           self#derive_of_core_type t ~allow_any_constr body x
 
-       method! derive_of_polyvariant ?td t (cs : row_field list) x =
+       method! derive_of_polyvariant ?td:_ t (cs : row_field list) x =
          let loc = t.ptyp_loc in
          let allow_any_constr =
            cs
@@ -588,9 +606,8 @@ module Conv = struct
                      Vcs_tuple (n, t)
                    in
                    let next =
-                     derive_of_variant_case ?td
-                       self#derive_of_core_type make case ~allow_any_constr
-                       next
+                     derive_of_variant_case self#derive_of_core_type
+                       make case ~allow_any_constr next
                    in
                    next, case :: cases
                | `Rinherit (n, ts) ->
@@ -617,13 +634,14 @@ module Conv = struct
            }
          in
          derive_of_variant self#derive_of_core_type t ~allow_any_constr
-           ?td body x
+           body x
      end
       :> deriving)
 
   let deriving_of_match ~name ~of_t ~cmp_sort_vcs ~derive_of_tuple
       ~derive_of_record
-      ~(derive_of_variant_case : ?td:_ -> _ -> _ -> _ -> _) () =
+      ~(derive_of_variant_case :
+         ?is_compact_variants:bool -> _ -> _ -> _ -> _) () =
     (object (self)
        inherit Schema.deriving1
        method name = name
@@ -641,9 +659,11 @@ module Conv = struct
 
        method! derive_of_variant td cs x =
          let loc = td.ptype_loc in
+         let compact = is_compact_variants td in
          let error_message =
            Printf.sprintf "expected %s"
-             (get_constructor_names cs |> String.concat ~sep:" or ")
+             (get_constructor_names ~compact cs
+             |> String.concat ~sep:" or ")
          in
          let cs = repr_variant_cases cs in
          let cs =
@@ -677,8 +697,8 @@ module Conv = struct
                      in
                      Vcs_record (n, r)
                    in
-                   derive_of_variant_case self#derive_of_core_type ~td
-                     (make n) t
+                   derive_of_variant_case self#derive_of_core_type
+                     ~is_compact_variants:compact (make n) t
                    :: next
                | Pcstr_tuple ts ->
                    let t =
@@ -687,13 +707,13 @@ module Conv = struct
                      in
                      Vcs_tuple (n, t)
                    in
-                   derive_of_variant_case self#derive_of_core_type ~td
-                     (make n) t
+                   derive_of_variant_case self#derive_of_core_type
+                     ~is_compact_variants:compact (make n) t
                    :: next)
          in
          pexp_match ~loc x cases
 
-       method! derive_of_polyvariant ?td t (cs : row_field list) x =
+       method! derive_of_polyvariant ?td:_ t (cs : row_field list) x =
          let loc = t.ptyp_loc in
          let cases = repr_polyvariant_cases cs in
          let cases =
@@ -745,7 +765,7 @@ module Conv = struct
            List.fold_left ctors ~init:[ catch_all ]
              ~f:(fun next ((n : label loc), t) ->
                let make arg = pexp_variant ~loc:n.loc n.txt arg in
-               derive_of_variant_case ?td self#derive_of_core_type make t
+               derive_of_variant_case self#derive_of_core_type make t
                :: next)
          in
          pexp_match ~loc x cases
@@ -754,7 +774,7 @@ module Conv = struct
 
   let deriving_to ~name ~t_to ~derive_of_tuple ~derive_of_record
       ~(derive_of_variant_case :
-         ?td:type_declaration ->
+         ?is_compact_variants:bool ->
          derive_of_core_type ->
          variant_case ->
          expression list ->
@@ -785,6 +805,7 @@ module Conv = struct
 
        method! derive_of_variant td cs x =
          let loc = td.ptype_loc in
+         let compact = is_compact_variants td in
          let ctor_pat (n : label loc) pat =
            ppat_construct ~loc:n.loc (map_loc lident n) pat
          in
@@ -806,7 +827,7 @@ module Conv = struct
                       Vcs_record (n, t)
                     in
                     ctor_pat n (Some p)
-                    --> derive_of_variant_case ~td
+                    --> derive_of_variant_case ~is_compact_variants:compact
                           self#derive_of_core_type t es
                 | Pcstr_tuple ts ->
                     let arity = List.length ts in
@@ -818,10 +839,10 @@ module Conv = struct
                     in
                     let p, es = gen_pat_tuple ~loc "x" arity in
                     ctor_pat n (if arity = 0 then None else Some p)
-                    --> derive_of_variant_case ~td
+                    --> derive_of_variant_case ~is_compact_variants:compact
                           self#derive_of_core_type t es))
 
-       method! derive_of_polyvariant ?td t (cs : row_field list) x =
+       method! derive_of_polyvariant ?td:_ t (cs : row_field list) x =
          let loc = t.ptyp_loc in
          let cases = repr_polyvariant_cases cs in
          let cases =
@@ -836,16 +857,17 @@ module Conv = struct
                      Vcs_tuple (n, t)
                    in
                    ppat_variant ~loc n.txt None
-                   --> derive_of_variant_case ?td
-                         self#derive_of_core_type t []
+                   --> derive_of_variant_case self#derive_of_core_type
+                         t []
                | `Rtag (n, ts) ->
                    let t =
                      { tpl_loc = loc; tpl_types = ts; tpl_ctx = ctx }
                    in
                    let ps, es = gen_pat_tuple ~loc "x" (List.length ts) in
                    ppat_variant ~loc n.txt (Some ps)
-                   --> derive_of_variant_case ?td
-                         self#derive_of_core_type (Vcs_tuple (n, t)) es
+                   --> derive_of_variant_case self#derive_of_core_type
+                         (Vcs_tuple (n, t))
+                         es
                | `Rinherit (n, ts) ->
                    [%pat? [%p ppat_type ~loc n] as x]
                    --> self#derive_of_core_type

--- a/ppx/native/common/ppx_deriving_tools.mli
+++ b/ppx/native/common/ppx_deriving_tools.mli
@@ -88,7 +88,7 @@ module Conv : sig
       expression list ->
       expression) ->
     derive_of_variant_case:
-      (?td:type_declaration ->
+      (?is_compact_variants:bool ->
       derive_of_core_type ->
       variant_case ->
       expression list ->
@@ -109,15 +109,15 @@ module Conv : sig
       expression ->
       expression) ->
     derive_of_variant:
-      (derive_of_core_type ->
+      (?is_compact_variants:bool ->
+      derive_of_core_type ->
       variant ->
       allow_any_constr:(expression -> expression) option ->
-      ?td:type_declaration ->
       expression ->
       expression ->
       expression) ->
     derive_of_variant_case:
-      (?td:type_declaration ->
+      (?is_compact_variants:bool ->
       derive_of_core_type ->
       (expression option -> expression) ->
       variant_case ->
@@ -140,7 +140,7 @@ module Conv : sig
       expression ->
       expression) ->
     derive_of_variant_case:
-      (?td:type_declaration ->
+      (?is_compact_variants:bool ->
       derive_of_core_type ->
       (expression option -> expression) ->
       variant_case ->
@@ -209,7 +209,11 @@ class virtual deriving1 : object
   (** ESSENTIAL METHODS *)
 
   method derive_of_polyvariant :
-    ?td:type_declaration -> core_type -> row_field list -> expression -> expression
+    ?td:type_declaration ->
+    core_type ->
+    row_field list ->
+    expression ->
+    expression
 
   method derive_of_record :
     type_declaration -> label_declaration list -> expression -> expression

--- a/ppx/native/ppx_deriving_json_native.ml
+++ b/ppx/native/ppx_deriving_json_native.ml
@@ -131,8 +131,8 @@ module Of_json = struct
                 [%e estring ~loc (sprintf "expected a JSON object")]];
       ]
 
-  let derive_of_variant_case ?td derive make vcs =
-    let compact = Option.fold ~none:false ~some:is_compact_variants td in
+  let derive_of_variant_case ?(is_compact_variants = false) derive
+      make vcs =
     match vcs with
     | Vcs_tuple (n, t) when vcs_attr_json_allow_any t.tpl_ctx ->
         let loc = n.loc in
@@ -191,7 +191,7 @@ module Of_json = struct
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
-        if compact && arity = 0 then
+        if is_compact_variants && arity = 0 then
           [%pat? `String [%p pstring ~loc:n.loc n.txt]] --> make None
         else if arity = 0 then
           [%pat? `List [ `String [%p pstring ~loc:n.loc n.txt] ]]
@@ -286,8 +286,8 @@ module To_json = struct
         (let [%p pbnds] = [] in
          [%e e])]
 
-  let derive_of_variant_case ?td derive vcs es =
-    let compact = Option.fold ~none:false ~some:is_compact_variants td in
+  let derive_of_variant_case ?(is_compact_variants = false) derive
+      vcs es =
     match vcs with
     | Vcs_tuple (_n, t) when vcs_attr_json_allow_any t.tpl_ctx -> (
         match es with
@@ -331,7 +331,7 @@ module To_json = struct
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
-        if compact && arity = 0 then
+        if is_compact_variants && arity = 0 then
           [%expr `String [%e estring ~loc:n.loc n.txt]]
         else
           [%expr

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -1509,3 +1509,74 @@
   
     let _ = variant_any_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+  $ cat <<"EOF" | run
+  > type compact_variant = A | B of int [@@deriving json] [@@json.compact_variants]
+  > EOF
+  type compact_variant = A | B of int
+  [@@deriving json] [@@json.compact_variants]
+  
+  include struct
+    let _ = fun (_ : compact_variant) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec compact_variant_of_json =
+      (fun x ->
+         if Js.Array.isArray x then
+           let array = (Obj.magic x : Js.Json.t array) in
+           let len = Js.Array.length array in
+           if Stdlib.( > ) len 0 then
+             let tag = Js.Array.unsafe_get array 0 in
+             if Stdlib.( = ) (Js.typeof tag) "string" then
+               let tag = (Obj.magic tag : string) in
+               if Stdlib.( = ) tag "A" then A
+               else if Stdlib.( = ) tag "B" then
+                 if Stdlib.( <> ) len 2 then
+                   Melange_json.of_json_error ~json:x
+                     "expected a JSON array of length 2"
+                 else B (int_of_json (Js.Array.unsafe_get array 1))
+               else
+                 Melange_json.of_json_error ~json:x
+                   "expected [\"B\", _] or \"A\""
+             else
+               Melange_json.of_json_error ~json:x
+                 "expected a non empty JSON array with element being a \
+                  string"
+           else
+             Melange_json.of_json_error ~json:x
+               "expected a non empty JSON array"
+         else if Stdlib.( = ) (Js.typeof x) "string" then (
+           let array = (Obj.magic [||] : Js.Json.t array) in
+           let len = 0 in
+           let tag = (Obj.magic x : string) in
+           ignore (array, len);
+           if Stdlib.( = ) tag "A" then A
+           else if Stdlib.( = ) tag "B" then
+             if Stdlib.( <> ) len 2 then
+               Melange_json.of_json_error ~json:x
+                 "expected a JSON array of length 2"
+             else B (int_of_json (Js.Array.unsafe_get array 1))
+           else
+             Melange_json.of_json_error ~json:x
+               "expected [\"B\", _] or \"A\"")
+         else
+           Melange_json.of_json_error ~json:x
+             "expected a non empty JSON array"
+        : Js.Json.t -> compact_variant)
+  
+    let _ = compact_variant_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec compact_variant_to_json =
+      (fun x ->
+         match x with
+         | A -> (Obj.magic "A" : Js.Json.t)
+         | B x_0 ->
+             (Obj.magic [| (Obj.magic "B" : Js.Json.t); int_to_json x_0 |]
+               : Js.Json.t)
+        : compact_variant -> Js.Json.t)
+  
+    let _ = compact_variant_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -872,7 +872,7 @@
          | `List [ `String "B"; x_0 ] -> B (int_of_json x_0)
          | _ ->
              Melange_json.of_json_error ~json:x
-               "expected [\"A\"] or [\"B\", _]"
+               "expected \"A\" or [\"B\", _]"
         : Yojson.Basic.t -> compact_variant)
   
     let _ = compact_variant_of_json


### PR DESCRIPTION
## Fix error messages for `[@@json.compact_variants]`

### Problem

When `[@@json.compact_variants]` is applied to a variant type, nullary constructors are encoded as bare JSON strings (e.g. `"A"`), not arrays (e.g. `["A"]`). However, the error message generated for unknown tags still used the array format for nullary constructors, producing misleading messages like: `expected ["A"] or ["B", _]` when it should say: `expected "A" or ["B", _]`.



