### PR TITLE
Make extra JSON fields allowed by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- **[breaking]** PPX: Ignore extra JSON object fields by default in the native
+  PPX, matching the Melange PPX. Add `[@json.disallow_extra_fields]` for
+  records and inline records that should reject unknown keys.
 - Library: Add `Melange_json.unknown_variant_case`, a record type with
   fields `tag : string` and `payload : Melange_json.t list option`,
   meant to be referenced as the argument of a catch-all constructor (see

--- a/README.md
+++ b/README.md
@@ -234,50 +234,46 @@ let t = of_json (Melange_json.of_string {|{"a": 42}|})
 (* t = { a = 42; b = "-"; } *)
 ```
 
-#### `[@json.allow_extra_fields]` on records
+#### Extra fields on records
 
-Sometimes, the JSON objects might contain keys that are not part of the OCaml
-type definition. The `[@json.allow_extra_fields]` attribute allows you to
-gracefully ignore such additional fields instead of raising an error during
-deserialization.
-
-This attribute can be used on records, even when they are embedded in other
-types.
-
-> **Note:** For the Melange PPX, ignoring extra fields is the default behavior -
-> you don't need to explicitly add the `[@json.allow_extra_fields]` attribute.
-> The attribute is primarily useful for the native PPX where strict field
-> checking is the default.
-
-**Example 1: Ignoring extra fields in records**
+By default, both the native and Melange PPXs ignore JSON object keys that are
+not part of the OCaml record type.
 
 ```ocaml
-type allow_extra_fields = {
+type t = {
   a: int;
-} [@@deriving json] [@@json.allow_extra_fields]
+} [@@deriving json]
 
-let t = allow_extra_fields_of_json (Json.parseOrRaise {|{"a": 42, "extra": "ignore me"}|})
+let t = t_of_json (Melange_json.of_string {|{"a": 42, "extra": "ignore me"}|})
 (* t = { a = 42 } *)
 ```
 
-The additional key `"extra"` in the JSON input is ignored, and the record is
-successfully deserialized.
+`[@json.allow_extra_fields]` is still accepted for backwards compatibility, but
+is no longer necessary.
 
-**Example 2: Ignoring extra fields in inline records**
+Use `[@json.disallow_extra_fields]` to reject unknown keys and keep strict field
+checking. This attribute can be used on regular records and on inline records in
+variant constructors.
 
 ```ocaml
-type allow_extra_fields2 = 
-  | A of { a: int } [@json.allow_extra_fields] 
-  [@@deriving json]
+type strict = {
+  a: int;
+} [@@deriving json] [@@json.disallow_extra_fields]
 
-let t = allow_extra_fields2_of_json (Json.parseOrRaise {|{"tag": "A", "a": 42, "extra": "ignore me"}|})
-(* t = A { a = 42 } *)
+let _ = strict_of_json (Melange_json.of_string {|{"a": 42, "extra": "fail"}|})
+(* raises: did not expect field "extra" *)
 ```
 
-In this case, the `[@json.allow_extra_fields]` attribute is applied directly to
-the inline record in the variant constructor. This allows the variant to ignore
-extra fields in the JSON payload while properly deserializing the fields that
-match the type definition.
+```ocaml
+type strict_inline =
+  | A of { a: int } [@json.disallow_extra_fields]
+  [@@deriving json]
+
+let _ =
+  strict_inline_of_json
+    (Melange_json.of_string {|["A", {"a": 42, "extra": "fail"}]|})
+(* raises: did not expect field "extra" *)
+```
 
 #### `[@json.option]`: a shortcut for `[@json.default None]`
 

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -23,11 +23,15 @@ module Of_json = struct
     let row = ptyp_object ~loc (List.map fs ~f) Closed in
     [%type: [%t row] Js.t]
 
-  let build_record ~loc derive (fs : label_declaration list) x make =
+  let build_record ~allow_extra_fields ~loc derive
+      (fs : label_declaration list) x make =
+    let field_key ld =
+      let n = ld.pld_name in
+      Option.value ~default:n (ld_attr_json_key ld)
+    in
     let handle_field fs ld =
       ( map_loc lident ld.pld_name,
-        let n = ld.pld_name in
-        let n = Option.value ~default:n (ld_attr_json_key ld) in
+        let n = field_key ld in
         [%expr
           match
             Js.Undefined.toOption
@@ -46,13 +50,41 @@ module Of_json = struct
                             (sprintf "expected field %S to be present"
                                n.txt)]]]] )
     in
-    [%expr
-      let fs = (Obj.magic [%e x] : [%t build_js_type ~loc fs]) in
-      [%e
-        make
-          (pexp_record ~loc
-             (List.map fs ~f:(handle_field [%expr fs]))
-             None)]]
+    let is_known_field name =
+      List.fold_left fs ~init:[%expr false] ~f:(fun acc ld ->
+          let n = field_key ld in
+          [%expr
+            Stdlib.( || )
+              (Stdlib.( = ) [%e name] [%e estring ~loc:n.loc n.txt])
+              [%e acc]])
+    in
+    let body =
+      [%expr
+        let fs = (Obj.magic [%e x] : [%t build_js_type ~loc fs]) in
+        [%e
+          make
+            (pexp_record ~loc
+               (List.map fs ~f:(handle_field [%expr fs]))
+               None)]]
+    in
+    if allow_extra_fields then body
+    else
+      [%expr
+        let keys =
+          Js.Dict.keys (Obj.magic [%e x] : Js.Json.t Js.Dict.t)
+        in
+        let len = Js.Array.length keys in
+        let rec iter i =
+          if Stdlib.( < ) i len then
+            let name = Js.Array.unsafe_get keys i in
+            if [%e is_known_field [%expr name]] then
+              iter (Stdlib.( + ) i 1)
+            else
+              Melange_json.of_json_error ~json:x
+                (Stdlib.Printf.sprintf {|did not expect field "%s"|} name)
+        in
+        iter 0;
+        [%e body]]
 
   let eis_json_object ~loc x =
     [%expr
@@ -103,9 +135,12 @@ module Of_json = struct
 
   let derive_of_record derive t x =
     let loc = t.rcd_loc in
+    let allow_extra_fields = td_allow_extra_fields t.rcd_ctx in
     [%expr
       [%e ensure_json_object ~loc x];
-      [%e build_record ~loc derive t.rcd_fields x Fun.id]]
+      [%e
+        build_record ~allow_extra_fields ~loc derive t.rcd_fields x
+          Fun.id]]
 
   let derive_of_variant _derive t ~allow_any_constr ?td body x =
     let loc = t.vrt_loc in
@@ -209,8 +244,13 @@ module Of_json = struct
                     let fs = Js.Array.unsafe_get array 1 in
                     [%e ensure_json_object ~loc [%expr fs]];
                     [%e
-                      build_record ~loc derive r.rcd_fields [%expr fs]
-                        (fun e -> make (Some e))]]]
+                      let allow_extra_fields =
+                        match r.rcd_ctx with
+                        | Vcs_ctx_variant cd -> cd_allow_extra_fields cd
+                        | Vcs_ctx_polyvariant _ -> true
+                      in
+                      build_record ~allow_extra_fields ~loc derive
+                        r.rcd_fields [%expr fs] (fun e -> make (Some e))]]]
           else [%e next]]
     | Vcs_tuple (n, t) ->
         let loc = n.loc in

--- a/ppx/native/common/ppx_deriving_json_common.ml
+++ b/ppx/native/common/ppx_deriving_json_common.ml
@@ -80,6 +80,39 @@ let cd_attr_json_allow_extra_fields =
     (attr_json_allow_extra_fields
        Attribute.Context.constructor_declaration)
 
+let attr_json_disallow_extra_fields ctx =
+  Attribute.declare "json.disallow_extra_fields" ctx
+    Ast_pattern.(pstr nil)
+    ()
+
+let td_attr_json_disallow_extra_fields =
+  Attribute.get
+    (attr_json_disallow_extra_fields Attribute.Context.type_declaration)
+
+let cd_attr_json_disallow_extra_fields =
+  Attribute.get
+    (attr_json_disallow_extra_fields
+       Attribute.Context.constructor_declaration)
+
+let allow_extra_fields ~loc allow disallow =
+  match allow, disallow with
+  | Some (), Some () ->
+      Location.raise_errorf ~loc
+        "[@json.allow_extra_fields] and [@json.disallow_extra_fields] are \
+         mutually exclusive"
+  | _, Some () -> false
+  | _ -> true
+
+let td_allow_extra_fields td =
+  allow_extra_fields ~loc:td.ptype_loc
+    (td_attr_json_allow_extra_fields td)
+    (td_attr_json_disallow_extra_fields td)
+
+let cd_allow_extra_fields cd =
+  allow_extra_fields ~loc:cd.pcd_loc
+    (cd_attr_json_allow_extra_fields cd)
+    (cd_attr_json_disallow_extra_fields cd)
+
 let ld_attr_json_default =
   Attribute.get
     (Attribute.declare "json.default" Attribute.Context.label_declaration

--- a/ppx/native/ppx_deriving_json_native.ml
+++ b/ppx/native/ppx_deriving_json_native.ml
@@ -42,13 +42,12 @@ module Of_json = struct
     with_refs ~loc "x" fs @@ fun ename ->
     let handle_field k v =
       let fail_case =
-        [%pat? name]
-        -->
-        if allow_extra_fields then [%expr ()]
+        if allow_extra_fields then [%pat? _] --> [%expr ()]
         else
-          [%expr
-            Melange_json.of_json_error ~json:x
-              (Stdlib.Printf.sprintf {|did not expect field "%s"|} name)]
+          [%pat? name]
+          --> [%expr
+                Melange_json.of_json_error ~json:x
+                  (Stdlib.Printf.sprintf {|did not expect field "%s"|} name)]
       in
       let cases =
         List.fold_left (List.rev fs) ~init:[ fail_case ]
@@ -117,9 +116,7 @@ module Of_json = struct
 
   let derive_of_record derive t x =
     let loc = t.rcd_loc in
-    let allow_extra_fields =
-      Option.is_some (td_attr_json_allow_extra_fields t.rcd_ctx)
-    in
+    let allow_extra_fields = td_allow_extra_fields t.rcd_ctx in
     pexp_match ~loc x
       [
         [%pat? `Assoc fs]
@@ -206,9 +203,8 @@ module Of_json = struct
         let n = Option.value ~default:n (vcs_attr_json_name t.rcd_ctx) in
         let allow_extra_fields =
           match t.rcd_ctx with
-          | Vcs_ctx_variant cd ->
-              Option.is_some (cd_attr_json_allow_extra_fields cd)
-          | Vcs_ctx_polyvariant _ -> false
+          | Vcs_ctx_variant cd -> cd_allow_extra_fields cd
+          | Vcs_ctx_polyvariant _ -> true
         in
         [%pat? `List [ `String [%p pstring ~loc:n.loc n.txt]; `Assoc fs ]]
         --> build_record ~allow_extra_fields ~loc derive t.rcd_fields

--- a/ppx/test/errors.t/prettify.ml
+++ b/ppx/test/errors.t/prettify.ml
@@ -16,6 +16,7 @@ type j = {
   d : int * float list * string;
 }
 [@@deriving json]
+[@@json.disallow_extra_fields]
 
 let () =
   In_channel.with_open_bin Sys.argv.(1) (fun file ->

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -21,6 +21,8 @@ type epoly = [ `a [@json.name "A_aliased"] | `b ] [@@deriving json]
 type ('a, 'b) p2 = A of 'a | B of 'b [@@deriving json]
 type allow_extra_fields = {a: int} [@@deriving json] [@@json.allow_extra_fields]
 type allow_extra_fields2 = A of {a: int} [@json.allow_extra_fields] [@@deriving json]
+type disallow_extra_fields = {a: int} [@@deriving json] [@@json.disallow_extra_fields]
+type disallow_extra_fields2 = A of {a: int} [@json.disallow_extra_fields] [@@deriving json]
 type drop_default_option = { a: int; b_opt: int option; [@option] [@json.drop_default] } [@@deriving json]
 type array_list = { a: int array; b: int list} [@@deriving json]
 type json = Melange_json.t
@@ -49,10 +51,10 @@ let of_json_cases = [
   C ({|["Ok", 1]|}, res_of_json, res_to_json, Ok 1);
   C ({|["Error", "oops"]|}, res_of_json, res_to_json, Error "oops");
   C ({|[42, "works"]|}, tuple_of_json, tuple_to_json, (42, "works"));
-  C ({|{"name":"N","age":1}|}, record_of_json, record_to_json, {name="N"; age=1});
+  C ({|{"name":"N","age":1,"extra":true}|}, record_of_json, record_to_json, {name="N"; age=1});
   C ({|["A"]|}, sum_of_json, sum_to_json, (A : sum));
   C ({|["B", 42]|}, sum_of_json, sum_to_json, (B 42 : sum));
-  C ({|["C", {"name": "cname"}]|}, sum_of_json, sum_to_json, (C {name="cname"} : sum));
+  C ({|["C", {"name": "cname", "extra": true}]|}, sum_of_json, sum_to_json, (C {name="cname"} : sum));
   C ({|["A"]|}, sum_of_json, sum_to_json, (A : sum));
   C ({|["S2", 42, "hello"]|}, sum2_of_json, sum2_to_json, (S2 (42, "hello")));
   C ({|["B", 42]|}, poly_of_json, poly_to_json, (`B 42 : poly));
@@ -72,6 +74,8 @@ let of_json_cases = [
   C ({|["B","ok"]|}, p2_of_json int_of_json string_of_json, p2_to_json int_to_json string_to_json, B "ok");
   C ({|{"a":1,"b":2}|}, allow_extra_fields_of_json, allow_extra_fields_to_json, {a=1});
   C ({|["A",{"a":1,"b":2}]|}, allow_extra_fields2_of_json, allow_extra_fields2_to_json, A {a=1});
+  C ({|{"a":3}|}, disallow_extra_fields_of_json, disallow_extra_fields_to_json, {a=3});
+  C ({|["A",{"a":4}]|}, disallow_extra_fields2_of_json, disallow_extra_fields2_to_json, A {a=4});
   C ({|{"a":1}|}, drop_default_option_of_json, drop_default_option_to_json, {a=1; b_opt=None});
   C ({|{"a":1,"b_opt":2}|}, drop_default_option_of_json, drop_default_option_to_json, {a=1; b_opt=Some 2});
   C ({|{"a":[1],"b":[2]}|}, array_list_of_json, array_list_to_json, {a=[|1|]; b=[2]});
@@ -108,6 +112,10 @@ let error_cases = [
   (* Should fail with "expected a JSON string representing a variant" *)
   C ({|42|}, color_of_json, color_to_json, Red);
   C ({|"Yellow"|}, color_of_json, color_to_json, Red);
+
+  (* Should fail with disallowed extra fields *)
+  C ({|{"a":1,"b":2}|}, disallow_extra_fields_of_json, disallow_extra_fields_to_json, {a=1});
+  C ({|["A",{"a":1,"b":2}]|}, disallow_extra_fields2_of_json, disallow_extra_fields2_to_json, A {a=1});
 
   (* Should fail with shape validation *)
   C ({|["Circle"]|}, shape_of_json, shape_to_json, Circle 1.0);

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -56,13 +56,13 @@
   JSON REPRINT: ["Error","oops"]
   JSON    DATA: [42, "works"]
   JSON REPRINT: [42,"works"]
-  JSON    DATA: {"name":"N","age":1}
+  JSON    DATA: {"name":"N","age":1,"extra":true}
   JSON REPRINT: {"name":"N","age":1}
   JSON    DATA: ["A"]
   JSON REPRINT: ["A"]
   JSON    DATA: ["B", 42]
   JSON REPRINT: ["B",42]
-  JSON    DATA: ["C", {"name": "cname"}]
+  JSON    DATA: ["C", {"name": "cname", "extra": true}]
   JSON REPRINT: ["C",{"name":"cname"}]
   JSON    DATA: ["A"]
   JSON REPRINT: ["A"]
@@ -102,6 +102,10 @@
   JSON REPRINT: {"a":1}
   JSON    DATA: ["A",{"a":1,"b":2}]
   JSON REPRINT: ["A",{"a":1}]
+  JSON    DATA: {"a":3}
+  JSON REPRINT: {"a":3}
+  JSON    DATA: ["A",{"a":4}]
+  JSON REPRINT: ["A",{"a":4}]
   JSON    DATA: {"a":1}
   JSON REPRINT: {"a":1}
   JSON    DATA: {"a":1,"b_opt":2}
@@ -130,6 +134,10 @@
   Got expected error: expected a non empty JSON array but got 42
   ERROR CASE DATA: "Yellow"
   Got expected error: expected a non empty JSON array but got "Yellow"
+  ERROR CASE DATA: {"a":1,"b":2}
+  Got expected error: did not expect field "b" but got {"a": _, "b": _}
+  ERROR CASE DATA: ["A",{"a":1,"b":2}]
+  Got expected error: did not expect field "b" but got ["A", {"a": 1, "b": 2}]
   ERROR CASE DATA: ["Circle"]
   Got expected error: expected a JSON array of length 2 but got ["Circle"]
   ERROR CASE DATA: ["Rectangle", 10.0]

--- a/ppx/test/ppx_deriving_json_js_errors.t
+++ b/ppx/test/ppx_deriving_json_js_errors.t
@@ -48,3 +48,10 @@
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: [@drop_default_if_json_equal] cannot be used with [@option]. Use [@drop_default] instead.
   [1]
+
+  $ echo 'type t = { a: int } [@@deriving json] [@@json.allow_extra_fields] [@@json.disallow_extra_fields]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  File "-", line 1, characters 0-96:
+  1 | type t = { a: int } [@@deriving json] [@@json.allow_extra_fields] [@@json.disallow_extra_fields]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@json.allow_extra_fields] and [@json.disallow_extra_fields] are mutually exclusive
+  [1]

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -45,13 +45,13 @@
   JSON REPRINT: ["Error","oops"]
   JSON    DATA: [42, "works"]
   JSON REPRINT: [42,"works"]
-  JSON    DATA: {"name":"N","age":1}
+  JSON    DATA: {"name":"N","age":1,"extra":true}
   JSON REPRINT: {"name":"N","age":1}
   JSON    DATA: ["A"]
   JSON REPRINT: ["A"]
   JSON    DATA: ["B", 42]
   JSON REPRINT: ["B",42]
-  JSON    DATA: ["C", {"name": "cname"}]
+  JSON    DATA: ["C", {"name": "cname", "extra": true}]
   JSON REPRINT: ["C",{"name":"cname"}]
   JSON    DATA: ["A"]
   JSON REPRINT: ["A"]
@@ -91,6 +91,10 @@
   JSON REPRINT: {"a":1}
   JSON    DATA: ["A",{"a":1,"b":2}]
   JSON REPRINT: ["A",{"a":1}]
+  JSON    DATA: {"a":3}
+  JSON REPRINT: {"a":3}
+  JSON    DATA: ["A",{"a":4}]
+  JSON REPRINT: ["A",{"a":4}]
   JSON    DATA: {"a":1}
   JSON REPRINT: {"a":1}
   JSON    DATA: {"a":1,"b_opt":2}
@@ -119,6 +123,10 @@
   Got expected error: expected ["Red"] or ["Green"] or ["Blue"] but got 42
   ERROR CASE DATA: "Yellow"
   Got expected error: expected ["Red"] or ["Green"] or ["Blue"] but got "Yellow"
+  ERROR CASE DATA: {"a":1,"b":2}
+  Got expected error: did not expect field "b" but got {"a": _, "b": _}
+  ERROR CASE DATA: ["A",{"a":1,"b":2}]
+  Got expected error: did not expect field "b" but got ["A", {"a": 1, "b": 2}]
   ERROR CASE DATA: ["Circle"]
   Got expected error: expected ["Circle", _] or ["Rectangle", _, _] or ["Point", { _ }] but got ["Circle"]
   ERROR CASE DATA: ["Rectangle", 10.0]

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -168,10 +168,7 @@
                    | "name" ->
                        x_name := Stdlib.Option.Some (string_of_json v)
                    | "age" -> x_age := Stdlib.Option.Some (int_of_json v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -239,10 +236,7 @@
                    | "my_name" ->
                        x_name := Stdlib.Option.Some (string_of_json v)
                    | "my_age" -> x_age := Stdlib.Option.Some (int_of_json v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -305,10 +299,7 @@
                    | "k" ->
                        x_k :=
                          Stdlib.Option.Some ((option_of_json int_of_json) v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -363,10 +354,7 @@
                    (match n' with
                    | "name" ->
                        x_name := Stdlib.Option.Some (string_of_json v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -764,7 +752,7 @@
                | (n', v) :: fs ->
                    (match n' with
                    | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
-                   | name -> ());
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -817,7 +805,7 @@
                | (n', v) :: fs ->
                    (match n' with
                    | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
-                   | name -> ());
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -924,10 +912,7 @@
                    | "b_opt" ->
                        x_b_opt :=
                          Stdlib.Option.Some ((option_of_json int_of_json) v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -998,10 +983,7 @@
                    (match n' with
                    | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
                    | "b" -> x_b := Stdlib.Option.Some (int_of_json v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -1069,10 +1051,7 @@
                    (match n' with
                    | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
                    | "b" -> x_b := Stdlib.Option.Some (int_of_json v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;
@@ -1137,10 +1116,7 @@
                    (match n' with
                    | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
                    | "b" -> x_b := Stdlib.Option.Some (int_of_json v)
-                   | name ->
-                       Melange_json.of_json_error ~json:x
-                         (Stdlib.Printf.sprintf
-                            {|did not expect field "%s"|} name));
+                   | _ -> ());
                    iter fs
              in
              iter fs;

--- a/ppx/test/ppx_deriving_json_native_errors.t
+++ b/ppx/test/ppx_deriving_json_native_errors.t
@@ -48,3 +48,10 @@
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: [@drop_default_if_json_equal] cannot be used with [@option]. Use [@drop_default] instead.
   [1]
+
+  $ echo 'type t = { a: int } [@@deriving json] [@@json.allow_extra_fields] [@@json.disallow_extra_fields]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  File "-", line 1, characters 0-96:
+  1 | type t = { a: int } [@@deriving json] [@@json.allow_extra_fields] [@@json.disallow_extra_fields]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@json.allow_extra_fields] and [@json.disallow_extra_fields] are mutually exclusive
+  [1]


### PR DESCRIPTION
## Why

The Melange PPX already ignores unknown JSON object fields by default. The native PPX was stricter unless users opted in with `[@json.allow_extra_fields]`, which made behavior inconsistent across targets.

## What

- Make extra fields ignored by default for native record decoders, matching Melange.
- Add `[@json.disallow_extra_fields]` for records and inline records that should reject unknown keys.
- Keep `[@json.allow_extra_fields]` accepted for backwards compatibility and reject using both attributes together.
- Update README, changelog, and PPX/e2e tests.

## Testing

- `dune runtest`
