### PR TITLE
allow @@compact_variants to parse ["Tag"] in addition to "Tag" for nullary variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@
 - PPX: Add `[@@json.compact_variants]` attribute for variant and polyvariant
   types. Encodes constructors without arguments as plain JSON strings and
   constructors with arguments as JSON arrays `["ConstructorName", arg1, ...]`.
+  The decoder now also accepts `["Tag"]` (singleton array) as equivalent to
+  `"Tag"` for nullary constructors, making the compact form a strict superset
+  of the standard array encoding.
 - Support `Ptype_open`, e.g. `type u = X.(x) [@@deriving json]`
   ([#60](https://github.com/melange-community/melange-json/pull/60))
 - Add support for `[@drop_default]` with `[@default]` to omit fields

--- a/ppx/native/ppx_deriving_json_native.ml
+++ b/ppx/native/ppx_deriving_json_native.ml
@@ -128,68 +128,83 @@ module Of_json = struct
                 [%e estring ~loc (sprintf "expected a JSON object")]];
       ]
 
-  let derive_of_variant_case ?(is_compact_variants = false) derive
-      make vcs =
+  let derive_of_variant_case ?(is_compact_variants = false) derive make
+      vcs =
     match vcs with
     | Vcs_tuple (n, t) when vcs_attr_json_allow_any t.tpl_ctx ->
         let loc = n.loc in
         [%pat? _] --> make (Some [%expr x])
-    | Vcs_tuple (n, t) when vcs_attr_json_catch_all t.tpl_ctx ->
+    | Vcs_tuple (n, t) when vcs_attr_json_catch_all t.tpl_ctx -> (
         let loc = n.loc in
-        (match t.tpl_types with
-         | [ _ ] ->
-             [%pat? (`String _ | `List (`String _ :: _)) as v]
-             --> [%expr
-                   let tag =
-                     match v with
-                     | `String s -> s
-                     | `List (`String s :: _) -> s
-                     | _ -> assert false
-                   in
-                   let payload =
-                     match v with
-                     | `String _ -> Stdlib.Option.None
-                     | `List (_ :: rest) -> Stdlib.Option.Some rest
-                     | _ -> assert false
-                   in
-                   [%e make (Some [%expr ({ tag; payload } : Melange_json.unknown_variant_case)])]]
-         | _ ->
-             Location.raise_errorf ~loc
-               "[@json.catch_all] requires exactly one argument: a record \
-                type with fields `tag : string` and \
-                `payload : Yojson.Basic.t list option` (typically \
-                [Melange_json.unknown_variant_case])")
-    | Vcs_record (_n, t) when vcs_attr_json_catch_all t.rcd_ctx ->
+        match t.tpl_types with
+        | [ _ ] ->
+            [%pat? (`String _ | `List (`String _ :: _)) as v]
+            --> [%expr
+                  let tag =
+                    match v with
+                    | `String s -> s
+                    | `List (`String s :: _) -> s
+                    | _ -> assert false
+                  in
+                  let payload =
+                    match v with
+                    | `String _ -> Stdlib.Option.None
+                    | `List (_ :: rest) -> Stdlib.Option.Some rest
+                    | _ -> assert false
+                  in
+                  [%e
+                    make
+                      (Some
+                         [%expr
+                           ({ tag; payload }
+                             : Melange_json.unknown_variant_case)])]]
+        | _ ->
+            Location.raise_errorf ~loc
+              "[@json.catch_all] requires exactly one argument: a record \
+               type with fields `tag : string` and `payload : \
+               Yojson.Basic.t list option` (typically \
+               [Melange_json.unknown_variant_case])")
+    | Vcs_record (_n, t) when vcs_attr_json_catch_all t.rcd_ctx -> (
         let loc = t.rcd_loc in
-        (match t.rcd_fields with
-         | [ { pld_name = { txt = "tag"; _ }; _ };
-             { pld_name = { txt = "payload"; _ }; _ } ] ->
-             [%pat? (`String _ | `List (`String _ :: _)) as v]
-             --> [%expr
-                   let tag =
-                     match v with
-                     | `String s -> s
-                     | `List (`String s :: _) -> s
-                     | _ -> assert false
-                   in
-                   let payload =
-                     match v with
-                     | `String _ -> Stdlib.Option.None
-                     | `List (_ :: rest) -> Stdlib.Option.Some rest
-                     | _ -> assert false
-                   in
-                   [%e make (Some [%expr ({ tag; payload } : Melange_json.unknown_variant_case)])]]
-         | _ ->
-             Location.raise_errorf ~loc
-               "[@json.catch_all] inline record must have exactly two \
-                fields named `tag` and `payload` (in that order), with \
-                types `string` and `Yojson.Basic.t list option`")
+        match t.rcd_fields with
+        | [
+         { pld_name = { txt = "tag"; _ }; _ };
+         { pld_name = { txt = "payload"; _ }; _ };
+        ] ->
+            [%pat? (`String _ | `List (`String _ :: _)) as v]
+            --> [%expr
+                  let tag =
+                    match v with
+                    | `String s -> s
+                    | `List (`String s :: _) -> s
+                    | _ -> assert false
+                  in
+                  let payload =
+                    match v with
+                    | `String _ -> Stdlib.Option.None
+                    | `List (_ :: rest) -> Stdlib.Option.Some rest
+                    | _ -> assert false
+                  in
+                  [%e
+                    make
+                      (Some
+                         [%expr
+                           ({ tag; payload }
+                             : Melange_json.unknown_variant_case)])]]
+        | _ ->
+            Location.raise_errorf ~loc
+              "[@json.catch_all] inline record must have exactly two \
+               fields named `tag` and `payload` (in that order), with \
+               types `string` and `Yojson.Basic.t list option`")
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
         if is_compact_variants && arity = 0 then
-          [%pat? `String [%p pstring ~loc:n.loc n.txt]] --> make None
+          [%pat?
+            ( `String [%p pstring ~loc:n.loc n.txt]
+            | `List [ `String [%p pstring ~loc:n.loc n.txt] ] )]
+          --> make None
         else if arity = 0 then
           [%pat? `List [ `String [%p pstring ~loc:n.loc n.txt] ]]
           --> make None
@@ -282,8 +297,8 @@ module To_json = struct
         (let [%p pbnds] = [] in
          [%e e])]
 
-  let derive_of_variant_case ?(is_compact_variants = false) derive
-      vcs es =
+  let derive_of_variant_case ?(is_compact_variants = false) derive vcs es
+      =
     match vcs with
     | Vcs_tuple (_n, t) when vcs_attr_json_allow_any t.tpl_ctx -> (
         match es with
@@ -304,20 +319,21 @@ module To_json = struct
         | _ ->
             Location.raise_errorf ~loc
               "[@json.catch_all] requires exactly one argument: a record \
-               type with fields `tag : string` and \
-               `payload : Yojson.Basic.t list option` (typically \
+               type with fields `tag : string` and `payload : \
+               Yojson.Basic.t list option` (typically \
                [Melange_json.unknown_variant_case])")
     | Vcs_record (_n, t) when vcs_attr_json_catch_all t.rcd_ctx -> (
         let loc = t.rcd_loc in
         match t.rcd_fields, es with
-        | ( [ { pld_name = { txt = "tag"; _ }; _ };
-              { pld_name = { txt = "payload"; _ }; _ } ],
+        | ( [
+              { pld_name = { txt = "tag"; _ }; _ };
+              { pld_name = { txt = "payload"; _ }; _ };
+            ],
             [ tag_e; payload_e ] ) ->
             [%expr
               match [%e payload_e] with
               | Stdlib.Option.None -> `String [%e tag_e]
-              | Stdlib.Option.Some xs ->
-                  `List (`String [%e tag_e] :: xs)]
+              | Stdlib.Option.Some xs -> `List (`String [%e tag_e] :: xs)]
         | _ ->
             Location.raise_errorf ~loc
               "[@json.catch_all] inline record must have exactly two \

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -38,8 +38,10 @@ type shape =
 
 let of_json_cases = [
   C ({|"Compact_variant"|}, compact_variant_of_json, compact_variant_to_json, (Compact_variant : compact_variant));
+  C ({|["Compact_variant"]|}, compact_variant_of_json, compact_variant_to_json, (Compact_variant : compact_variant));
   C ({|["Compact_variant_of_int",42]|}, compact_variant_of_json, compact_variant_to_json, (Compact_variant_of_int 42 : compact_variant));
   C ({|"Compact_polyvariant"|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant : compact_polyvariant));
+  C ({|["Compact_polyvariant"]|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant : compact_polyvariant));
   C ({|["Compact_polyvariant_of_int",42]|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant_of_int 42 : compact_polyvariant));
   C ({|1|}, user_of_json, user_to_json, 1);
   C ({|"9223372036854775807"|}, userid_of_json, userid_to_json, 9223372036854775807L);

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -25,29 +25,138 @@
   > ' >> main.ml
 
   $ dune build @js
-  File "example.ml", line 80, characters 37-77:
-  80 |   C ({|["A",{"a":5,"extra":true}]|}, disallow_extra_fields_wrong_attr_of_json, disallow_extra_fields_wrong_attr_to_json, A {a=5});
-                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Unbound value disallow_extra_fields_wrong_attr_of_json
-  [1]
 
   $ node ./_build/default/output/main.js
-  node:internal/modules/cjs/loader:1368
-    throw err;
-    ^
+  *** json deriver tests ***
+  JSON    DATA: "Compact_variant"
+  JSON REPRINT: "Compact_variant"
+  JSON    DATA: ["Compact_variant"]
+  JSON REPRINT: "Compact_variant"
+  JSON    DATA: ["Compact_variant_of_int",42]
+  JSON REPRINT: ["Compact_variant_of_int",42]
+  JSON    DATA: "Compact_polyvariant"
+  JSON REPRINT: "Compact_polyvariant"
+  JSON    DATA: ["Compact_polyvariant"]
+  JSON REPRINT: "Compact_polyvariant"
+  JSON    DATA: ["Compact_polyvariant_of_int",42]
+  JSON REPRINT: ["Compact_polyvariant_of_int",42]
+  JSON    DATA: 1
+  JSON REPRINT: 1
+  JSON    DATA: "9223372036854775807"
+  JSON REPRINT: "9223372036854775807"
+  JSON    DATA: 1.1
+  JSON REPRINT: 1.1
+  JSON    DATA: 1.0
+  JSON REPRINT: 1
+  JSON    DATA: 42
+  JSON REPRINT: 42
+  JSON    DATA: "OK"
+  JSON REPRINT: "OK"
+  JSON    DATA: "some"
+  JSON REPRINT: "some"
+  JSON    DATA: ["Ok", 1]
+  JSON REPRINT: ["Ok",1]
+  JSON    DATA: ["Error", "oops"]
+  JSON REPRINT: ["Error","oops"]
+  JSON    DATA: [42, "works"]
+  JSON REPRINT: [42,"works"]
+  JSON    DATA: {"name":"N","age":1,"extra":true}
+  JSON REPRINT: {"name":"N","age":1}
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["C", {"name": "cname", "extra": true}]
+  JSON REPRINT: ["C",{"name":"cname"}]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["S2", 42, "hello"]
+  JSON REPRINT: ["S2",42,"hello"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["C"]
+  JSON REPRINT: ["C"]
+  JSON    DATA: ["P2", 42, "hello"]
+  JSON REPRINT: ["P2",42,"hello"]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["b_aliased"]
+  JSON REPRINT: ["b_aliased"]
+  JSON    DATA: ["b"]
+  JSON REPRINT: ["b"]
+  JSON    DATA: ["A_aliased"]
+  JSON REPRINT: ["A_aliased"]
+  JSON    DATA: {"my_name":"N","my_age":1}
+  JSON REPRINT: {"my_name":"N","my_age":1}
+  JSON    DATA: {"my_name":"N"}
+  JSON REPRINT: {"my_name":"N","my_age":100}
+  JSON    DATA: {}
+  JSON REPRINT: {"k":null}
+  JSON    DATA: {"k":42}
+  JSON REPRINT: {"k":42}
+  JSON    DATA: ["A",1]
+  JSON REPRINT: ["A",1]
+  JSON    DATA: ["B","ok"]
+  JSON REPRINT: ["B","ok"]
+  JSON    DATA: {"a":1,"b":2}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: ["A",{"a":1,"b":2}]
+  JSON REPRINT: ["A",{"a":1}]
+  JSON    DATA: {"a":3}
+  JSON REPRINT: {"a":3}
+  JSON    DATA: ["A",{"a":4}]
+  JSON REPRINT: ["A",{"a":4}]
+  JSON    DATA: {"a":1}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: {"a":1,"b_opt":2}
+  JSON REPRINT: {"a":1,"b_opt":2}
+  JSON    DATA: {"a":[1],"b":[2]}
+  JSON REPRINT: {"a":[1],"b":[2]}
+  JSON    DATA: ["Circle", 5.0]
+  JSON REPRINT: ["Circle",5]
+  JSON    DATA: ["Rectangle", 10.0, 20.0]
+  JSON REPRINT: ["Rectangle",10,20]
+  JSON    DATA: ["Point", {"x": 1.0, "y": 2.0}]
+  JSON REPRINT: ["Point",{"x":1,"y":2}]
   
-  Error: Cannot find module '$TESTCASE_ROOT/_build/default/output/main.js'
-      at Function._resolveFilename (node:internal/modules/cjs/loader:1365:15)
-      at defaultResolveImpl (node:internal/modules/cjs/loader:1021:19)
-      at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1026:22)
-      at Function._load (node:internal/modules/cjs/loader:1175:37)
-      at TracingChannel.traceSync (node:diagnostics_channel:322:14)
-      at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
-      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
-      at node:internal/main/run_main_module:36:49 {
-    code: 'MODULE_NOT_FOUND',
-    requireStack: []
-  }
-  
-  Node.js v22.18.0
-  [1]
+  Testing error cases:
+  ERROR CASE DATA: 42
+  Got expected error: expected a JSON object but got 42
+  ERROR CASE DATA: [1]
+  Got expected error: expected a JSON array of length 2 but got [1]
+  ERROR CASE DATA: [1,2,3]
+  Got expected error: expected a JSON array of length 2 but got [1, 2, 3]
+  ERROR CASE DATA: [1,2]
+  Got expected error: expected a JSON array of length 3 but got [1, 2]
+  ERROR CASE DATA: [1,2,3,4]
+  Got expected error: expected a JSON array of length 3 but got [1, 2, 3, 4]
+  ERROR CASE DATA: 42
+  Got expected error: expected a non empty JSON array but got 42
+  ERROR CASE DATA: "Yellow"
+  Got expected error: expected a non empty JSON array but got "Yellow"
+  ERROR CASE DATA: {"a":1,"b":2}
+  Got expected error: did not expect field "b" but got {"a": _, "b": _}
+  ERROR CASE DATA: ["A",{"a":1,"b":2}]
+  Got expected error: did not expect field "b" but got ["A", {"a": 1, "b": 2}]
+  ERROR CASE DATA: ["Circle"]
+  Got expected error: expected a JSON array of length 2 but got ["Circle"]
+  ERROR CASE DATA: ["Rectangle", 10.0]
+  Got expected error: expected a JSON array of length 3 but got ["Rectangle", 10]
+  ERROR CASE DATA: ["Point", 1.0, 2.0]
+  Got expected error: expected a JSON array of length 2 but got ["Point", 1, 2]
+  *** json_string deriver tests ***
+  ** To_json_string **
+  A 42 -> ["A",42]
+  B false -> ["B",false]
+  ** Of_json_string **
+  ["A", 42] = A 42 -> true
+  ["B", false] = B false -> true
+  ** Json_string **
+  A 42 -> ["A",42]
+  B false -> ["B",false]
+  ["A", 42] = A 42 -> true
+  ["B", false] = B false -> true

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -15,15 +15,137 @@
   > ' >> main.ml
 
   $ dune build ./main.exe
-  File "example.ml", line 80, characters 37-77:
-  80 |   C ({|["A",{"a":5,"extra":true}]|}, disallow_extra_fields_wrong_attr_of_json, disallow_extra_fields_wrong_attr_to_json, A {a=5});
-                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Unbound value disallow_extra_fields_wrong_attr_of_json
-  [1]
 
   $ dune exec ./main.exe
-  File "example.ml", line 80, characters 37-77:
-  80 |   C ({|["A",{"a":5,"extra":true}]|}, disallow_extra_fields_wrong_attr_of_json, disallow_extra_fields_wrong_attr_to_json, A {a=5});
-                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: Unbound value disallow_extra_fields_wrong_attr_of_json
-  [1]
+  JSON    DATA: "Compact_variant"
+  JSON REPRINT: "Compact_variant"
+  JSON    DATA: ["Compact_variant"]
+  JSON REPRINT: "Compact_variant"
+  JSON    DATA: ["Compact_variant_of_int",42]
+  JSON REPRINT: ["Compact_variant_of_int",42]
+  JSON    DATA: "Compact_polyvariant"
+  JSON REPRINT: "Compact_polyvariant"
+  JSON    DATA: ["Compact_polyvariant"]
+  JSON REPRINT: "Compact_polyvariant"
+  JSON    DATA: ["Compact_polyvariant_of_int",42]
+  JSON REPRINT: ["Compact_polyvariant_of_int",42]
+  JSON    DATA: 1
+  JSON REPRINT: 1
+  JSON    DATA: "9223372036854775807"
+  JSON REPRINT: "9223372036854775807"
+  JSON    DATA: 1.1
+  JSON REPRINT: 1.1
+  JSON    DATA: 1.0
+  JSON REPRINT: 1.0
+  JSON    DATA: 42
+  JSON REPRINT: 42.0
+  JSON    DATA: "OK"
+  JSON REPRINT: "OK"
+  JSON    DATA: "some"
+  JSON REPRINT: "some"
+  JSON    DATA: ["Ok", 1]
+  JSON REPRINT: ["Ok",1]
+  JSON    DATA: ["Error", "oops"]
+  JSON REPRINT: ["Error","oops"]
+  JSON    DATA: [42, "works"]
+  JSON REPRINT: [42,"works"]
+  JSON    DATA: {"name":"N","age":1,"extra":true}
+  JSON REPRINT: {"name":"N","age":1}
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["C", {"name": "cname", "extra": true}]
+  JSON REPRINT: ["C",{"name":"cname"}]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["S2", 42, "hello"]
+  JSON REPRINT: ["S2",42,"hello"]
+  JSON    DATA: ["B", 42]
+  JSON REPRINT: ["B",42]
+  JSON    DATA: ["C"]
+  JSON REPRINT: ["C"]
+  JSON    DATA: ["P2", 42, "hello"]
+  JSON REPRINT: ["P2",42,"hello"]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON REPRINT: ["Fix",["Fix",["Fix",["A"]]]]
+  JSON    DATA: ["A"]
+  JSON REPRINT: ["A"]
+  JSON    DATA: ["b_aliased"]
+  JSON REPRINT: ["b_aliased"]
+  JSON    DATA: ["b"]
+  JSON REPRINT: ["b"]
+  JSON    DATA: ["A_aliased"]
+  JSON REPRINT: ["A_aliased"]
+  JSON    DATA: {"my_name":"N","my_age":1}
+  JSON REPRINT: {"my_name":"N","my_age":1}
+  JSON    DATA: {"my_name":"N"}
+  JSON REPRINT: {"my_name":"N","my_age":100}
+  JSON    DATA: {}
+  JSON REPRINT: {"k":null}
+  JSON    DATA: {"k":42}
+  JSON REPRINT: {"k":42}
+  JSON    DATA: ["A",1]
+  JSON REPRINT: ["A",1]
+  JSON    DATA: ["B","ok"]
+  JSON REPRINT: ["B","ok"]
+  JSON    DATA: {"a":1,"b":2}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: ["A",{"a":1,"b":2}]
+  JSON REPRINT: ["A",{"a":1}]
+  JSON    DATA: {"a":3}
+  JSON REPRINT: {"a":3}
+  JSON    DATA: ["A",{"a":4}]
+  JSON REPRINT: ["A",{"a":4}]
+  JSON    DATA: {"a":1}
+  JSON REPRINT: {"a":1}
+  JSON    DATA: {"a":1,"b_opt":2}
+  JSON REPRINT: {"a":1,"b_opt":2}
+  JSON    DATA: {"a":[1],"b":[2]}
+  JSON REPRINT: {"a":[1],"b":[2]}
+  JSON    DATA: ["Circle", 5.0]
+  JSON REPRINT: ["Circle",5.0]
+  JSON    DATA: ["Rectangle", 10.0, 20.0]
+  JSON REPRINT: ["Rectangle",10.0,20.0]
+  JSON    DATA: ["Point", {"x": 1.0, "y": 2.0}]
+  JSON REPRINT: ["Point",{"x":1.0,"y":2.0}]
+  
+  Testing error cases:
+  ERROR CASE DATA: 42
+  Got expected error: expected a JSON object but got 42
+  ERROR CASE DATA: [1]
+  Got expected error: expected a JSON array of length 2 but got [1]
+  ERROR CASE DATA: [1,2,3]
+  Got expected error: expected a JSON array of length 2 but got [1, 2, 3]
+  ERROR CASE DATA: [1,2]
+  Got expected error: expected a JSON array of length 3 but got [1, 2]
+  ERROR CASE DATA: [1,2,3,4]
+  Got expected error: expected a JSON array of length 3 but got [1, 2, 3, 4]
+  ERROR CASE DATA: 42
+  Got expected error: expected ["Red"] or ["Green"] or ["Blue"] but got 42
+  ERROR CASE DATA: "Yellow"
+  Got expected error: expected ["Red"] or ["Green"] or ["Blue"] but got "Yellow"
+  ERROR CASE DATA: {"a":1,"b":2}
+  Got expected error: did not expect field "b" but got {"a": _, "b": _}
+  ERROR CASE DATA: ["A",{"a":1,"b":2}]
+  Got expected error: did not expect field "b" but got ["A", {"a": 1, "b": 2}]
+  ERROR CASE DATA: ["Circle"]
+  Got expected error: expected ["Circle", _] or ["Rectangle", _, _] or ["Point", { _ }] but got ["Circle"]
+  ERROR CASE DATA: ["Rectangle", 10.0]
+  Got expected error: expected ["Circle", _] or ["Rectangle", _, _] or ["Point", { _ }] but got ["Rectangle", 10.]
+  ERROR CASE DATA: ["Point", 1.0, 2.0]
+  Got expected error: expected ["Circle", _] or ["Rectangle", _, _] or ["Point", { _ }] but got ["Point", 1., 2.]
+  *** json_string deriver tests ***
+  ** To_json_string **
+  A 42 -> ["A",42]
+  B false -> ["B",false]
+  ** Of_json_string **
+  ["A", 42] = A 42 -> true
+  ["B", false] = B false -> true
+  ** Json_string **
+  A 42 -> ["A",42]
+  B false -> ["B",false]
+  ["A", 42] = A 42 -> true
+  ["B", false] = B false -> true

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -856,7 +856,7 @@
     let rec compact_variant_of_json =
       (fun x ->
          match x with
-         | `String "A" -> A
+         | `String "A" | `List (`String "A" :: []) -> A
          | `List [ `String "B"; x_0 ] -> B (int_of_json x_0)
          | _ ->
              Melange_json.of_json_error ~json:x


### PR DESCRIPTION
# Summary

`@@compact_variants` makes nullary variant constructors serialize as a bare JSON string (`"Tag"`) instead of a singleton array (`["Tag"]`). This PR makes the decoder accept **both** forms on input, so `["Tag"]` and `"Tag"` are treated as equivalent when decoding.

- **Native backend**: extended the match arm for compact nullary variants from a bare-string-only pattern to an or-pattern (`"Tag" | ["Tag"]`). The encoder is unchanged — it still emits the compact `"Tag"` form, so `["Tag"]` round-trips to `"Tag"`.
- **Browser backend**: no code change needed — the existing array path already handled `["Tag"]` for compact nullary variants (it extracts `tag` from `array[0]` and runs the same tag-equality check regardless of array length).

## Motivation

This makes `@@compact_variants` a strict