### PR TITLE
Add jsonschema deriver

### DIFF
--- a/JSONSCHEMA.md
+++ b/JSONSCHEMA.md
@@ -1,0 +1,1113 @@
+# `[@@deriving jsonschema]`
+
+`[@@deriving jsonschema]` generates a [JSON Schema](https://json-schema.org/)
+(draft 2020-12) from an OCaml type. It is the
+[`ppx_deriving_jsonschema`](https://github.com/ahrefs/ppx_deriving_jsonschema)
+deriver, integrated into melange-json and registered through the same PPX as
+`[@@deriving json]`.
+
+The generated schema is compatible with the wire format produced by the other
+json derivers:
+
+- [melange-json](https://github.com/melange-community/melange-json) (`[@@deriving json]`)
+- [ppx_deriving_yojson](https://github.com/ocaml-ppx/ppx_deriving_yojson)
+- [ppx_yojson_conv](https://github.com/janestreet/ppx_yojson_conv)
+
+## Setup
+
+The deriver ships inside the melange-json PPX, so there is nothing extra to
+install — enabling `melange-json.ppx` (Melange) or `melange-json-native.ppx`
+(native) makes `[@@deriving jsonschema]` available. The generated code relies on
+a small runtime that the PPX wires in automatically as a `ppx_runtime_library`:
+
+| Build      | PPX                       | Runtime                       |
+| ---------- | ------------------------- | ----------------------------- |
+| Melange/JS | `melange-json.ppx`        | `melange-json.jsonschema`        |
+| Native     | `melange-json-native.ppx` | `melange-json-native.jsonschema` |
+
+Both runtime libraries expose the same `Ppx_deriving_jsonschema_runtime` module.
+
+A native `dune` stanza looks like:
+
+```dune
+(library
+ (name my_types)
+ (preprocess
+  (pps melange-json-native.ppx)))
+```
+
+and a Melange one:
+
+```dune
+(library
+ (name my_types)
+ (modes melange)
+ (preprocess
+  (pps melange-json.ppx)))
+```
+
+## `[@@deriving jsonschema]`
+
+```ocaml
+type address = {
+  street: string;
+  city: string;
+  zip: string;
+} [@@deriving jsonschema]
+
+type t = {
+  name: string;
+  age: int;
+  email: string option;
+  address: address;
+} [@@deriving jsonschema]
+
+let schema = Ppx_deriving_jsonschema_runtime.json_schema t_jsonschema
+```
+
+Such a type will be turned into a JSON schema like this:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "zip": { "type": "string" },
+        "city": { "type": "string" },
+        "street": { "type": "string" }
+      },
+      "required": [ "zip", "city", "street" ],
+      "additionalProperties": false
+    },
+    "email": { "type": "string" },
+    "age": { "type": "integer" },
+    "name": { "type": "string" }
+  },
+  "required": [ "address", "age", "name" ],
+  "additionalProperties": false
+}
+```
+
+## Usage
+
+For each type with `[@@deriving jsonschema]`, the deriver generates a
+`<type>_jsonschema` value of type `Ppx_deriving_jsonschema_runtime.t`.
+Wrap it with `Ppx_deriving_jsonschema_runtime.json_schema` to get a complete,
+self-contained schema document (it adds the `$schema` header and any
+`$defs`/metadata).
+
+The deriver emits primitive helpers (e.g. `int_jsonschema`, `string_jsonschema`)
+unqualified, so bring the right primitives module into scope depending on the
+build. Use `Melange_json` for the Melange runtime and `Yojson` for the native
+one:
+
+```ocaml
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
+
+type t = {
+  a: int;
+  b: string;
+} [@@deriving jsonschema]
+```
+
+### Conversion rules
+
+#### Primitives
+
+As we support the ppx to be used with both melange-json and yojson, we provide two primitives modules: `Melange_json` and `Yojson`.
+
+##### Melange_json
+
+<table>
+<thead>
+<tr><th>OCaml type</th><th>JSON schema</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>char</code></td>
+<td>
+
+```json
+{ "type": "string", "minLength": 1, "maxLength": 1 }
+```
+
+</tr>
+<tr>
+<td><code>int</code></td>
+<td>
+
+```json
+{ "type": "integer" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>int64</code></td>
+<td>
+
+```json
+{ "type": "string", "description": "int64 is represented as a string" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>float</code></td>
+<td>
+
+```json
+{ "type": "number" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>bool</code></td>
+<td>
+
+```json
+{ "type": "boolean" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td>
+
+```json
+{ "type": "string" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>list</code>, <code>array</code></td>
+<td>
+
+```json
+{ "type": "array", "items": { "type": "..." } }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>'a option</code></td>
+<td>
+
+```json
+{ "type": ["...", "null"] }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>unit</code></td>
+<td>
+
+```json
+{ "type": "null" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>result('a, 'b)</code></td>
+<td>
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Error" }, { "type": "..." } ],
+      "unevaluatedItems": false,
+      "minItems": 1
+    },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Ok" }, { "type": "..." } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+
+##### Yojson
+
+<table>
+<thead>
+<tr><th>OCaml type</th><th>JSON schema</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>char</code></td>
+<td>
+
+```json
+{ "type": "string", "minLength": 1, "maxLength": 1 }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>int</code>, <code>int64</code></td>
+<td>
+
+```json
+{ "type": "number" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>float</code></td>
+<td>
+
+```json
+{ "type": "number" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>bool</code></td>
+<td>
+
+```json
+{ "type": "boolean" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>string</code></td>
+<td>
+
+```json
+{ "type": "string" }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>list</code>, <code>array</code></td>
+<td>
+
+```json
+{ "type": "array", "items": { "type": "..." } }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>'a option</code></td>
+<td>
+
+```json
+{ "type": ["...", "null"] }
+```
+
+</td>
+</tr>
+<tr>
+<td><code>unit</code></td>
+<td>
+
+```json
+{ "type": "null" }
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+#### Ref
+
+Type `'a ref` is treated as `'a`.
+
+```ocaml
+type t = {
+  name : string ref;
+} [@@deriving jsonschema]
+```
+
+```json
+{ "type": "string" }
+```
+
+#### Option
+
+Option types are converted to `{ "type": ["...", "null"] }` and added to the `required` list.
+
+```ocaml
+type t = {
+  name : string option;
+} [@@deriving jsonschema]
+```
+
+```json
+{ 
+  "type": "object", 
+  "properties": { 
+    "name": { 
+      "type": [ "string", "null" ] 
+    },
+  },
+  "required": [ "name" ], 
+  "additionalProperties": false 
+}
+```
+
+To make a field optional, use the `[@@jsonschema.option]` attribute:
+
+```ocaml
+type t = {
+  name : string option; [@jsonschema.option]
+} [@@deriving jsonschema]
+```
+
+```json
+{ 
+  "type": "object", 
+  "properties": { 
+    "name": { 
+      "type": [ "string", "null" ] 
+    },
+  },
+  "required": [], 
+  "additionalProperties": false 
+}
+```
+#### Result
+
+`('ok, 'err) result` is converted to an `anyOf` with two array variants, matching the standard variant encoding:
+
+```ocaml
+type result_value = (int, string) result [@@deriving jsonschema]
+```
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Error" }, { "type": "integer" } ],
+      "unevaluatedItems": false,
+      "minItems": 1
+    },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Ok" }, { "type": "string" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+#### List and arrays
+
+OCaml lists and arrays are converted to `{ "type": "array", "items": { "type": "..." } }`.
+
+#### Tuples
+
+Tuples are converted to `{ "type": "array", "prefixItems": [...] }`.
+
+```ocaml
+type t = int * string [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "array",
+  "prefixItems": [ { "type": "integer" }, { "type": "string" } ],
+  "unevaluatedItems": false,
+  "minItems": 2,
+  "maxItems": 2
+}
+```
+
+#### Variants and polymorphic variants
+
+By default, constructors in variants are represented as a list with one string, which is the name of the contructor. Constructors with arguments are represented as lists, the first element being the constructor name, the rest being its arguments. It reproduces the representation of `ppx_deriving_yojson` and `ppx_yojson_conv`. For example:
+
+```ocaml
+type t =
+| Typ
+| Class of string
+[@@deriving jsonschema]
+```
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Typ" } ],
+      "unevaluatedItems": false,
+      "minItems": 1,
+      "maxItems": 1
+    },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Class" }, { "type": "string" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+Note that the implicit tuple in a polymorphic variant is flattened. This can be disabled using the `~polymorphic_variant_tuple` flag.
+
+```ocaml
+type a = [ `A of int * string * bool ] [@@deriving jsonschema]
+```
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [
+        { "const": "A" },
+        { "type": "integer" },
+        { "type": "string" },
+        { "type": "boolean" }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 4,
+      "maxItems": 4
+    }
+  ]
+}
+```
+
+```ocaml
+type b = [ `B of int * string * bool ] [@@deriving jsonschema ~polymorphic_variant_tuple]
+```
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [
+        { "const": "B" },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "type": "integer" },
+            { "type": "string" },
+            { "type": "boolean" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 3,
+          "maxItems": 3
+        }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+A `~variant_as_string` flag is exposed to obtain a more natural representation `"anyOf": [{ "const": "..." }, ...]`. This representation does _not_ support payloads. For example:
+
+```ocaml
+type t =
+| Typ
+| Class of string
+[@@deriving jsonschema ~variant_as_string]
+```
+
+```json
+{ "anyOf": [ { "const": "Typ" }, { "const": "Class" } ] }
+```
+
+If the JSON variant names differ from OCaml conventions, it is possible to specify the corresponding JSON string explicitly using `[@name "constr"]`, for example:
+
+```ocaml
+type t =
+| Typ   [@name "type"]
+| Class of string [@name "class"]
+[@@deriving jsonschema ~variant_as_string]
+```
+
+```json
+{ "anyOf": [ { "const": "type" }, { "const": "class" } ] }
+```
+
+A `[@@jsonschema.compact_variants]` attribute offers a middle ground. Unlike `~variant_as_string`, it only collapses payload-free constructors to a bare `{ "const": "..." }`; constructors with arguments keep the standard array encoding. It therefore supports payloads.
+
+```ocaml
+type t =
+| A
+| B
+| C of int
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+```
+
+```json
+{
+  "anyOf": [
+    { "const": "A" },
+    { "const": "B" },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "C" }, { "type": "integer" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+It works the same way on polymorphic variants: payload-free constructors collapse to `{ "const": "..." }`, while constructors with arguments keep the array encoding.
+
+```ocaml
+type t =
+[ `Aaa
+| `Bbb
+| `Ccc of int
+]
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+```
+
+```json
+{
+  "anyOf": [
+    { "const": "Aaa" },
+    { "const": "Bbb" },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "Ccc" }, { "type": "integer" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+#### Records
+
+Records are converted to `{ "type": "object", "properties": {...}, "required": [...], "additionalProperties": false }`.
+
+The fields of type `option` are not included in the `required` list.
+
+By default, additionalProperties are not allowed in objects. To allow additionalProperties, use the `allow_extra_fields` attribute:
+
+```ocaml
+type company = {
+  name : string;
+  employees : int;
+}
+[@@deriving jsonschema]
+[@@jsonschema.allow_extra_fields]
+```
+
+This annotation will generate a schema with `"additionalProperties": true`, allowing for additional fields not defined in the record:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" }
+  },
+  "required": [ "name", "age" ],
+  "additionalProperties": true
+}
+```
+
+When the JSON object keys differ from the ocaml field names, users can specify the corresponding JSON key implicitly using `[@key "field"]`, for example:
+
+```ocaml
+type t = {
+  typ    : float [@key "type"];
+  class_ : float [@key "CLASS"];
+}
+[@@deriving jsonschema]
+```
+
+#### Inline Records in Variants
+
+You can use the `[@jsonschema.allow_extra_fields]` attribute on a constructor with an inline record to allow additional fields in that record:
+
+```ocaml
+type inline_record_with_extra_fields =
+  | User of { name : string; email : string } [@jsonschema.allow_extra_fields]
+  | Guest of { ip : string }
+[@@deriving jsonschema]
+```
+
+This will generate a schema that allows additional fields for the `User` variant's record but not for the `Guest` variant:
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [
+        { "const": "User" },
+        {
+          "type": "object",
+          "properties": {
+            "email": { "type": "string" },
+            "name": { "type": "string" }
+          },
+          "required": [ "email", "name" ],
+          "additionalProperties": true
+        }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    {
+      "type": "array",
+      "prefixItems": [
+        { "const": "Guest" },
+        {
+          "type": "object",
+          "properties": { "ip": { "type": "string" } },
+          "required": [ "ip" ],
+          "additionalProperties": false
+        }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```
+
+#### References
+
+Rather than inlining the definition of a type it is possible to use a [json schema `$ref`](https://json-schema.org/understanding-json-schema/structuring#dollarref) using the `[@ref "name"]` attribute. In such a case, the type definition must be passed to `Ppx_deriving_jsonschema_runtime.json_schema` as a parameter.
+
+```ocaml
+type address = {
+  street : string;
+  city : string;
+  zip : string;
+}
+[@@deriving jsonschema]
+
+type t = {
+  name : string;
+  age : int;
+  email : string option;
+  home_address : address; [@ref "shared_address"]
+  work_address : address; [@ref "shared_address"]
+  retreat_address : address; [@ref "shared_address"]
+}
+[@@deriving jsonschema]
+
+let schema =
+  Ppx_deriving_jsonschema_runtime.json_schema
+    ~definitions:[("shared_address", address_jsonschema)]
+    t_jsonschema
+```
+
+Would produce the following schema:
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "shared_address": {
+      "type": "object",
+      "properties": {
+        "zip": { "type": "string" },
+        "city": { "type": "string" },
+        "street": { "type": "string" }
+      },
+      "required": [ "zip", "city", "street" ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "retreat_address": { "$ref": "#/$defs/shared_address" },
+    "work_address": { "$ref": "#/$defs/shared_address" },
+    "home_address": { "$ref": "#/$defs/shared_address" },
+    "email": { "type": "string" },
+    "age": { "type": "integer" },
+    "name": { "type": "string" }
+  },
+  "required": [
+    "retreat_address", "work_address", "home_address", "age", "name"
+  ]
+}
+```
+
+#### Recursive Types
+
+Recursive types are automatically detected and handled using JSON Schema's `$defs` and `$ref` mechanism.
+
+##### Self-referential types
+
+```ocaml
+type tree =
+  | Leaf
+  | Node of { value : int; left : tree; right : tree }
+[@@deriving jsonschema]
+```
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "tree": {
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Leaf" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Node" },
+            {
+              "type": "object",
+              "properties": {
+                "right": { "$ref": "#/$defs/tree" },
+                "left": { "$ref": "#/$defs/tree" },
+                "value": { "type": "integer" }
+              },
+              "required": [ "right", "left", "value" ],
+              "additionalProperties": false
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+  },
+  "$ref": "#/$defs/tree"
+}
+```
+
+##### Mutually recursive types
+
+Mutually recursive types (defined with `and`) are also supported:
+
+```ocaml
+type expr =
+  | Literal of int
+  | Binary of expr * expr
+  | Block of stmt list
+
+and stmt =
+  | ExprStmt of expr
+  | IfStmt of { cond : expr; then_ : stmt; else_ : stmt option }
+[@@deriving jsonschema]
+```
+
+This generates `expr_jsonschema` containing all definitions in `$defs`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "expr": {
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Literal" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Binary" },
+            { "$ref": "#/$defs/expr" },
+            { "$ref": "#/$defs/expr" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 3,
+          "maxItems": 3
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Block" },
+            { "type": "array", "items": { "$ref": "#/$defs/stmt" } }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    "stmt": {
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "ExprStmt" }, { "$ref": "#/$defs/expr" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "IfStmt" },
+            {
+              "type": "object",
+              "properties": {
+                "else_": { "$ref": "#/$defs/stmt" },
+                "then_": { "$ref": "#/$defs/stmt" },
+                "cond": { "$ref": "#/$defs/expr" }
+              },
+              "required": [ "then_", "cond" ],
+              "additionalProperties": false
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    }
+  },
+  "$ref": "#/$defs/expr"
+}
+```
+
+The secondary type `stmt_jsonschema` is also a self-contained schema, with the same `$defs` but `$ref` pointing to its own type:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "expr": { ... },
+    "stmt": { ... }
+  },
+  "$ref": "#/$defs/stmt"
+}
+```
+
+
+### Annotations
+
+#### `[@@jsonschema.description]` ([REF](https://www.learnjsonschema.com/2020-12/meta-data/description/))
+
+Add a description to a type or a field. It can be used on a type, a field, a variant constructor, or directly on a core type (e.g. a variant payload).
+
+```ocaml
+type t = {
+  name : string [@jsonschema.description "The user's full name"];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "description": "The user's full name", "type": "string" }
+  },
+  "required": [ "name" ],
+  "additionalProperties": false
+}
+```
+
+When the `~ocaml_doc` flag is passed to the deriver, an OCaml doc comment (`(** ... *)`, stored in the AST as an `ocaml.doc` attribute) is used as the description when `[@jsonschema.description]` is not provided. The explicit attribute takes precedence. Without the flag, doc comments are ignored.
+
+```ocaml
+type t = {
+  name : string;  (** The user's full name *)
+} [@@deriving jsonschema ~ocaml_doc]
+(** A user object *)
+```
+
+```json
+{
+  "description": "A user object",
+  "type": "object",
+  "properties": {
+    "name": { "description": "The user's full name", "type": "string" }
+  },
+  "required": [ "name" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@@jsonschema.format]` ([REF](https://www.learnjsonschema.com/2020-12/format-annotation/))
+
+Add a format annotation to a string-typed field. It can be used on a type, a field, or directly on a core type (e.g. a variant payload). Only applies to `string` and `bytes` types.
+
+```ocaml
+type t = {
+  name : string [@jsonschema.format "date-time"]; 
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "format": "date-time", "type": "string" }
+  },
+  "required": [ "name" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@@jsonschema.maximum]` ([REF](https://www.learnjsonschema.com/2020-12/validation/maximum/))
+
+Add a maximum value to a type or a field. It can be used on a type, a field, or a variant payload. Only applies to numeric types (`int`, `int32`, `nativeint`, `float`).
+
+```ocaml
+type t = {
+  score : int [@jsonschema.maximum 100];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "score": { "maximum": 100, "type": "integer" }
+  },
+  "required": [ "score" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@@jsonschema.minimum]` ([REF](https://www.learnjsonschema.com/2020-12/validation/minimum/))
+
+Add a minimum value to a type or a field. It can be used on a type, a field, or a variant payload. Only applies to numeric types (`int`, `int32`, `nativeint`, `float`).
+
+```ocaml
+type t = {
+  score : int [@jsonschema.minimum 0];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "score": { "minimum": 0, "type": "integer" }
+  },
+  "required": [ "score" ],
+  "additionalProperties": false
+}
+```
+
+#### `[@jsonschema.default]` ([REF](https://www.learnjsonschema.com/2020-12/meta-data/default/))
+
+Set a default value for a record field. Fields with a default are excluded from `required`.
+
+Primitive literals (`int`, `int32`, `nativeint`, `float`, `string`, `bytes`, `bool`) and **their** `option`, `list`, `tuple`, and `array` variants are serialized automatically. 
+For non-primitive types (custom variants, records, etc.) a `<type>_to_json` function must be in scope — e.g. via `[@@deriving json]` from melange-json. (`<type> -> Js.Json.t` at melange and `<type> -> Yojson.Basic.t` at native)
+
+```ocaml
+type status = Active | Inactive [@@deriving jsonschema]
+let status_to_json = function
+  | Active -> `String "Active"
+  | Inactive -> `String "Inactive"
+
+type t = {
+  score    : int option;  [@jsonschema.default 0]
+  label    : string;      [@jsonschema.default "unlabelled"]
+  is_admin : bool;        [@jsonschema.default false]
+  tags     : string list; [@jsonschema.default ["general"]]
+  status   : status;      [@jsonschema.default Active]
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "score":    { "default": 0,             "type": [ "integer", "null" ] },
+    "label":    { "default": "unlabelled",  "type": "string" },
+    "is_admin": { "default": false,         "type": "boolean" },
+    "tags":     { "default": [ "general" ], "type": "array", "items": { "type": "string" } },
+    "status":   { "default": [ "Active" ],  "anyOf": [ ... ] }
+  },
+  "required": [],
+  "additionalProperties": false
+}
+```
+
+#### `[@jsonschema.attrs]`
+
+A composite annotation that bundles multiple schema attributes into a single record expression. Supported fields: `description`, `format`, `maximum`, `minimum`. Type-sensitive fields (`format`, `maximum`, `minimum`) are validated against the annotated type.
+
+Can be used on core types, label declarations, and type declarations.
+
+```ocaml
+type t = {
+  score : int [@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }];
+  created_at : string [@jsonschema.attrs { format = "date-time"; description = "Creation timestamp" }];
+} [@@deriving jsonschema]
+```
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "score": { "minimum": 0, "maximum": 100, "description": "Score out of 100", "type": "integer" },
+    "created_at": { "format": "date-time", "description": "Creation timestamp", "type": "string" }
+  },
+  "required": [ "score", "created_at" ],
+  "additionalProperties": false
+}
+```
+
+It can also be applied directly to a core type in a variant payload:
+
+```ocaml
+type t =
+  | Score of (int [@jsonschema.attrs { maximum = 100; minimum = 0; description = "Percentage" }])
+[@@deriving jsonschema]
+```
+
+```json
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [
+        { "const": "Score" },
+        { "minimum": 0, "maximum": 100, "description": "Percentage", "type": "integer" }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -519,6 +519,26 @@ val to_json : t -> Yojson.Basic.json
 Refer to the [PPX for Melange](#ppx-for-melange) section for more details on
 usage patterns.
 
+## JSON Schema (`[@@deriving jsonschema]`)
+
+The PPX can generate a [JSON Schema](https://json-schema.org/) from a type with
+`[@@deriving jsonschema]`. The schema matches the output produced by the
+json derivers.
+
+```ocaml
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
+
+type t = {
+  name: string;
+  age: int;
+} [@@deriving jsonschema]
+
+let schema = Ppx_deriving_jsonschema_runtime.json_schema t_jsonschema
+```
+
+See **[JSONSCHEMA.md](./JSONSCHEMA.md)** for the full documentation: setup,
+conversion rules, and all supported annotations.
+
 ## License
 
 This work is dual-licensed under LGPL 3.0 and MPL 2.0. You can choose between

--- a/ppx/browser/dune
+++ b/ppx/browser/dune
@@ -3,7 +3,7 @@
  (name ppx_deriving_json_js)
  (modules :standard \ ppx_deriving_json_js_test)
  (libraries ppxlib)
- (ppx_runtime_libraries melange-json)
+ (ppx_runtime_libraries melange-json melange-json.jsonschema)
  (preprocess
   (pps ppxlib.metaquot))
  (kind ppx_deriver))
@@ -32,3 +32,8 @@
 
 (copy_files#
  (files ../native/common/ppx_deriving_tools.{ml,mli}))
+
+; Shared jsonschema deriver sources (see ppx/native/dune for rationale). Compiled
+; into melange-json.ppx so [@@deriving jsonschema] works on the Melange ppx too.
+(copy_files#
+ (files ../jsonschema/{attrs,schema,ppx_deriving_jsonschema}.{ml,mli}))

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -434,4 +434,5 @@ let () =
   let (_ : Deriving.t) = Of_json_string.register ~of_json () in
   let (_ : Deriving.t) = To_json_string.register ~to_json () in
   let (_ : Deriving.t) = Json_string.register ~json () in
+  let (_ : Deriving.t) = Ppx_deriving_jsonschema.register () in
   ()

--- a/ppx/jsonschema/attrs.ml
+++ b/ppx/jsonschema/attrs.ml
@@ -1,0 +1,137 @@
+open Ppxlib
+
+type config = {
+  variant_as_string : bool;
+    (** Encode variants as string instead of string array. This option breaks compatibility with yojson derivers and
+        doesn't support constructors with a payload. *)
+  polymorphic_variant_tuple : bool;
+    (** Preserve the implicit tuple in a polymorphic variant. This option breaks compatibility with yojson derivers. *)
+  ocaml_doc : bool;
+    (** Use [ocaml.doc] attributes (i.e. [(** ... *)] comments) as a fallback for [[@jsonschema.description]] when the
+        explicit annotation is absent. *)
+}
+
+let string_attr name ctx = Attribute.declare name ctx Ast_pattern.(single_expr_payload (estring __')) (fun x -> x)
+
+let expr_attr name ctx = Attribute.declare name ctx Ast_pattern.(single_expr_payload __) (fun x -> x)
+
+let jsonschema_key = string_attr "jsonschema.key" Attribute.Context.label_declaration
+let jsonschema_ref = string_attr "jsonschema.ref" Attribute.Context.label_declaration
+let jsonschema_variant_name = string_attr "jsonschema.name" Attribute.Context.constructor_declaration
+let jsonschema_polymorphic_variant_name = string_attr "jsonschema.name" Attribute.Context.rtag
+
+let jsonschema_td_allow_extra_fields =
+  Attribute.declare "jsonschema.allow_extra_fields" Attribute.Context.type_declaration
+    Ast_pattern.(pstr nil)
+    (fun () -> ())
+
+let jsonschema_cd_allow_extra_fields =
+  Attribute.declare "jsonschema.allow_extra_fields" Attribute.Context.constructor_declaration
+    Ast_pattern.(pstr nil)
+    (fun () -> ())
+
+let jsonschema_option = Attribute.declare_flag "jsonschema.option" Attribute.Context.label_declaration
+
+let jsonschema_ld_description = string_attr "jsonschema.description" Attribute.Context.label_declaration
+let jsonschema_td_description = string_attr "jsonschema.description" Attribute.Context.type_declaration
+let jsonschema_cd_description = string_attr "jsonschema.description" Attribute.Context.constructor_declaration
+let jsonschema_ct_description = string_attr "jsonschema.description" Attribute.Context.core_type
+let jsonschema_rtag_description = string_attr "jsonschema.description" Attribute.Context.rtag
+
+let jsonschema_td_format = string_attr "jsonschema.format" Attribute.Context.type_declaration
+let jsonschema_ld_format = string_attr "jsonschema.format" Attribute.Context.label_declaration
+let jsonschema_ct_format = string_attr "jsonschema.format" Attribute.Context.core_type
+
+let jsonschema_td_maximum = expr_attr "jsonschema.maximum" Attribute.Context.type_declaration
+let jsonschema_ld_maximum = expr_attr "jsonschema.maximum" Attribute.Context.label_declaration
+let jsonschema_ct_maximum = expr_attr "jsonschema.maximum" Attribute.Context.core_type
+
+let jsonschema_td_minimum = expr_attr "jsonschema.minimum" Attribute.Context.type_declaration
+let jsonschema_ld_minimum = expr_attr "jsonschema.minimum" Attribute.Context.label_declaration
+let jsonschema_ct_minimum = expr_attr "jsonschema.minimum" Attribute.Context.core_type
+
+let jsonschema_ct_attrs = expr_attr "jsonschema.attrs" Attribute.Context.core_type
+let jsonschema_td_attrs = expr_attr "jsonschema.attrs" Attribute.Context.type_declaration
+let jsonschema_ld_attrs = expr_attr "jsonschema.attrs" Attribute.Context.label_declaration
+let jsonschema_ld_default = expr_attr "jsonschema.default" Attribute.Context.label_declaration
+
+(* We intentionally do not use [Attribute.get] for [ocaml.doc]/[doc]. These are
+   compiler-reserved attributes, and [ppxlib] rejects registering them via
+   [Attribute.declare]. We therefore inspect the raw attribute list directly
+   with an [Ast_pattern] that matches both the name and the standard string
+   payload shape in one go. *)
+let doc_attr_pattern =
+  Ast_pattern.(attribute ~name:(string "ocaml.doc" ||| string "doc") ~payload:(single_expr_payload (estring __')))
+
+(* A node can carry several [ocaml.doc]/[doc] attributes — e.g. a user writing
+   one doc comment before a record field and another after. We collect every
+   match and join them with a blank line so each comment reads as its own
+   paragraph. The returned location is that of the first matching attribute. *)
+let find_doc_attr attrs =
+  let matches =
+    List.filter_map
+      (fun attr ->
+        Ast_pattern.parse_res doc_attr_pattern attr.attr_loc attr Fun.id
+        |> Result.to_option
+        |> Option.map (fun ({ txt; loc } : string Location.loc) -> { txt = String.trim txt; loc }))
+      attrs
+  in
+  match matches with
+  | [] -> None
+  | [ single ] -> Some single
+  | first :: _ as all -> Some { txt = String.concat "\n\n" (List.map (fun x -> x.txt) all); loc = first.loc }
+
+let fallback_description ~ocaml_doc explicit_desc attrs node =
+  match Attribute.get explicit_desc node with
+  | Some _ as x -> x
+  | None -> if ocaml_doc then find_doc_attr attrs else None
+
+let ld_description ~ocaml_doc (ld : label_declaration) =
+  fallback_description ~ocaml_doc jsonschema_ld_description ld.pld_attributes ld
+
+let td_description ~ocaml_doc (td : type_declaration) =
+  fallback_description ~ocaml_doc jsonschema_td_description td.ptype_attributes td
+
+let cd_description ~ocaml_doc (cd : constructor_declaration) =
+  fallback_description ~ocaml_doc jsonschema_cd_description cd.pcd_attributes cd
+
+let ct_description ~ocaml_doc (ct : core_type) =
+  fallback_description ~ocaml_doc jsonschema_ct_description ct.ptyp_attributes ct
+
+let rtag_description ~ocaml_doc (rf : row_field) =
+  fallback_description ~ocaml_doc jsonschema_rtag_description rf.prf_attributes rf
+
+let jsonschema_td_compact_variants =
+  Attribute.declare_flag "jsonschema.compact_variants" Attribute.Context.type_declaration
+
+let attributes =
+  [
+    Attribute.T jsonschema_key;
+    Attribute.T jsonschema_ref;
+    Attribute.T jsonschema_variant_name;
+    Attribute.T jsonschema_polymorphic_variant_name;
+    Attribute.T jsonschema_td_allow_extra_fields;
+    Attribute.T jsonschema_cd_allow_extra_fields;
+    Attribute.T jsonschema_option;
+    Attribute.T jsonschema_ld_description;
+    Attribute.T jsonschema_td_description;
+    Attribute.T jsonschema_cd_description;
+    Attribute.T jsonschema_ct_description;
+    Attribute.T jsonschema_rtag_description;
+    Attribute.T jsonschema_td_format;
+    Attribute.T jsonschema_ld_format;
+    Attribute.T jsonschema_ct_format;
+    Attribute.T jsonschema_td_maximum;
+    Attribute.T jsonschema_ld_maximum;
+    Attribute.T jsonschema_ct_maximum;
+    Attribute.T jsonschema_td_minimum;
+    Attribute.T jsonschema_ld_minimum;
+    Attribute.T jsonschema_ct_minimum;
+    Attribute.T jsonschema_ct_attrs;
+    Attribute.T jsonschema_td_attrs;
+    Attribute.T jsonschema_ld_attrs;
+    Attribute.T jsonschema_ld_default;
+    Attribute.T jsonschema_td_compact_variants;
+  ]
+
+let args () = Deriving.Args.(empty +> flag "variant_as_string" +> flag "polymorphic_variant_tuple" +> flag "ocaml_doc")

--- a/ppx/jsonschema/attrs.mli
+++ b/ppx/jsonschema/attrs.mli
@@ -1,0 +1,50 @@
+type config = {
+  variant_as_string : bool;
+    (** Encode variants as string instead of string array. This option breaks compatibility with yojson derivers and
+        doesn't support constructors with a payload. *)
+  polymorphic_variant_tuple : bool;
+    (** Preserve the implicit tuple in a polymorphic variant. This option breaks compatibility with yojson derivers. *)
+  ocaml_doc : bool;
+    (** Use [ocaml.doc] attributes (i.e. [(** ... *)] comments) as a fallback for [[@jsonschema.description]] when the
+        explicit annotation is absent. *)
+}
+
+val jsonschema_key : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ref : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_variant_name : (Ppxlib.constructor_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_polymorphic_variant_name : (Ppxlib.row_field, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_allow_extra_fields : (Ppxlib.type_declaration, unit -> unit) Ppxlib.Attribute.t
+val jsonschema_cd_allow_extra_fields : (Ppxlib.constructor_declaration, unit -> unit) Ppxlib.Attribute.t
+val jsonschema_option : Ppxlib.label_declaration Ppxlib.Attribute.flag
+val jsonschema_ld_description : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_description : (Ppxlib.type_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_cd_description : (Ppxlib.constructor_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ct_description : (Ppxlib.core_type, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_rtag_description : (Ppxlib.row_field, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_format : (Ppxlib.type_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ld_format : (Ppxlib.label_declaration, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_ct_format : (Ppxlib.core_type, string Location.loc) Ppxlib.Attribute.t
+val jsonschema_td_maximum : (Ppxlib.type_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ld_maximum : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ct_maximum : (Ppxlib.core_type, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_td_minimum : (Ppxlib.type_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ld_minimum : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ct_minimum : (Ppxlib.core_type, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ct_attrs : (Ppxlib.core_type, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_td_attrs : (Ppxlib.type_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ld_attrs : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+val jsonschema_ld_default : (Ppxlib.label_declaration, Ppxlib.expression) Ppxlib.Attribute.t
+
+(** [ld_description], [td_description], [cd_description], [ct_description] and [rtag_description] resolve a description
+    from [[@jsonschema.description "..."]]. When [ocaml_doc] is [true] and the explicit annotation is absent, they fall
+    back to an [ocaml.doc] attribute (i.e. a [(** ... *)] comment) on the same node. *)
+val ld_description : ocaml_doc:bool -> Ppxlib.label_declaration -> string Location.loc option
+
+val td_description : ocaml_doc:bool -> Ppxlib.type_declaration -> string Location.loc option
+val cd_description : ocaml_doc:bool -> Ppxlib.constructor_declaration -> string Location.loc option
+val ct_description : ocaml_doc:bool -> Ppxlib.core_type -> string Location.loc option
+val rtag_description : ocaml_doc:bool -> Ppxlib.row_field -> string Location.loc option
+
+val jsonschema_td_compact_variants : Ppxlib.type_declaration Ppxlib.Attribute.flag
+val attributes : Ppxlib.Attribute.packed list
+val args : unit -> (bool -> bool -> bool -> 'a, 'a) Ppxlib.Deriving.Args.t

--- a/ppx/jsonschema/ppx_deriving_jsonschema.ml
+++ b/ppx/jsonschema/ppx_deriving_jsonschema.ml
@@ -1,0 +1,414 @@
+open Ppxlib
+open Ast_builder.Default
+
+let deriver_name = "jsonschema"
+
+let value_name_pattern ~loc type_name = ppat_var ~loc { txt = type_name ^ "_jsonschema"; loc }
+
+let create_value ~loc name value = [%stri let[@warning "-32-39"] [%p value_name_pattern ~loc name] = [%e value]]
+
+(* Wraps [body] in nested lambdas, one per type parameter.
+   Parametric types like [('a, 'b) t] derive as [fun a b -> <schema>],
+   so callers can pass schemas for each type variable.
+   Use [~prefix:"_"] to mark params unused in the body. *)
+let wrap_type_params ~loc ?(prefix = "") params body =
+  List.fold_right
+    (fun param body -> [%expr fun [%p ppat_var ~loc { txt = prefix ^ param; loc }] -> [%e body]])
+    params body
+
+(* schema_of_core_type and schema_of_poly_variant are mutually recursive.
+   All other functions only call downward and use plain let. *)
+let rec schema_of_core_type ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) core_type =
+  let loc = core_type.ptyp_loc in
+  let schema, is_rec =
+    match core_type with
+    | [%type: int] | [%type: int32] | [%type: nativeint] -> [%expr int_jsonschema], false
+    | [%type: int64] -> [%expr int64_jsonschema], false
+    | [%type: float] -> [%expr float_jsonschema], false
+    | [%type: string] | [%type: bytes] -> [%expr string_jsonschema], false
+    | [%type: bool] -> [%expr bool_jsonschema], false
+    | [%type: char] -> [%expr char_jsonschema], false
+    | [%type: unit] -> [%expr unit_jsonschema], false
+    | [%type: [%t? t] result] ->
+      let expr, is_rec = schema_of_core_type ~config ~recursive_types t in
+      [%expr result_jsonschema [%e expr]], is_rec
+    | [%type: [%t? t] option] ->
+      let s, is_rec = schema_of_core_type ~config ~recursive_types t in
+      [%expr option_jsonschema [%e s]], is_rec
+    | [%type: [%t? t] ref] -> schema_of_core_type ~config ~recursive_types t
+    | [%type: [%t? t] list] ->
+      let t, is_rec = schema_of_core_type ~config ~recursive_types t in
+      [%expr list_jsonschema [%e t]], is_rec
+    | [%type: [%t? t] array] ->
+      let t, is_rec = schema_of_core_type ~config ~recursive_types t in
+      [%expr array_jsonschema [%e t]], is_rec
+    | _ ->
+    match core_type.ptyp_desc with
+    | Ptyp_var name -> evar ~loc name, false
+    | Ptyp_constr (id, args) ->
+      (match id.txt with
+      | Lident name when List.mem name recursive_types ->
+        (* Recursive reference: emit $ref regardless of type arguments. *)
+        Schema.type_ref ~loc name, true
+      | _ ->
+        let results = List.map (schema_of_core_type ~config ~recursive_types) args in
+        let args = List.map fst results in
+        let is_rec = List.exists snd results in
+        let schema = type_constr_conv ~loc id ~f:(fun s -> s ^ "_jsonschema") args in
+        let edv = evar ~loc "ppx_eds" in
+        (match is_rec with
+        | true ->
+          (* Hoist $defs from the sub-schema into the parent accumulator and strip
+             resource boundary markers ($defs), leaving just the $ref. *)
+          ( [%expr
+              match [%e schema] with
+              | `Assoc ppx_pairs ->
+                (match Stdlib.List.assoc_opt "$defs" ppx_pairs with
+                | Some (`Assoc ppx_defs) ->
+                  [%e edv] :=
+                    ![%e edv] @ Stdlib.List.filter (fun (n, _) -> not (Stdlib.List.mem_assoc n ![%e edv])) ppx_defs;
+                  `Assoc (Stdlib.List.filter (fun (k, _) -> not (Stdlib.String.equal k "$defs")) ppx_pairs)
+                | _ -> `Assoc ppx_pairs)
+              | ppx_other -> ppx_other],
+            is_rec )
+        | false ->
+          (* Non-recursive arg (or no accumulator): add a location-based $id to mark
+             the resource boundary so that any internal $defs refs resolve correctly. *)
+          let unique_id = estring ~loc (Printf.sprintf "file://%s:%d" loc.loc_start.pos_fname loc.loc_start.pos_lnum) in
+          ( [%expr
+              match [%e schema] with
+              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                `Assoc
+                  (("$id", `String [%e unique_id])
+                  :: Stdlib.List.filter (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs)
+              | other -> other],
+            is_rec )))
+    | Ptyp_tuple types ->
+      let results = List.map (schema_of_core_type ~config ~recursive_types) types in
+      let ts = List.map fst results in
+      let is_rec = List.exists snd results in
+      Schema.tuple ~loc ts, is_rec
+    | Ptyp_variant (row_fields, _, _) ->
+      schema_of_poly_variant ~loc ~config ~recursive_types ~compact_variants row_fields
+    | _ ->
+      let msg = Format.asprintf "ppx_deriving_jsonschema: unsupported type %a" Astlib.Pprintast.core_type core_type in
+      [%expr [%ocaml.error [%e estring ~loc msg]]], false
+  in
+  let schema =
+    schema
+    |> Schema.Annotation.add_description ~loc (Attrs.ct_description ~ocaml_doc:config.Attrs.ocaml_doc core_type)
+    |> Schema.Annotation.add_format ~loc (Attrs.jsonschema_ct_format, core_type) core_type
+    |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_ct_maximum, core_type) core_type
+    |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_ct_minimum, core_type) core_type
+    |> Schema.Annotation.add_annotations ~loc ~core_type (Attribute.get Attrs.jsonschema_ct_attrs core_type)
+  in
+  schema, is_rec
+
+and schema_of_poly_variant ~loc ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) row_fields
+    =
+  let constrs, is_rec =
+    List.fold_left
+      (fun (constrs, is_rec) row_field ->
+        let description_opt =
+          Option.map (fun d -> d.txt) (Attrs.rtag_description ~ocaml_doc:config.Attrs.ocaml_doc row_field)
+        in
+        match row_field.prf_desc with
+        | Rtag (name, true, []) ->
+          let name =
+            match Attribute.get Attrs.jsonschema_polymorphic_variant_name row_field with
+            | Some name -> name.txt
+            | None -> name.txt
+          in
+          `Tag (name, [], description_opt) :: constrs, is_rec
+        | Rtag (name, false, [ typ ]) ->
+          let name =
+            match Attribute.get Attrs.jsonschema_polymorphic_variant_name row_field with
+            | Some name -> name.txt
+            | None -> name.txt
+          in
+          let raw_typs =
+            match config.Attrs.polymorphic_variant_tuple with
+            | true -> [ typ ]
+            | false ->
+            match typ.ptyp_desc with
+            | Ptyp_tuple tps -> tps
+            | _ -> [ typ ]
+          in
+          let results = List.map (schema_of_core_type ~config ~recursive_types) raw_typs in
+          let typs = List.map fst results in
+          let typs_rec = List.exists snd results in
+          `Tag (name, typs, description_opt) :: constrs, is_rec || typs_rec
+        | Rtag (_, true, [ _ ]) | Rtag (_, _, _ :: _ :: _) ->
+          Location.raise_errorf ~loc "ppx_deriving_jsonschema: polymorphic_variant/Rtag/&"
+        | Rinherit core_type ->
+          let typ, typ_rec = schema_of_core_type ~config ~recursive_types core_type in
+          `Inherit typ :: constrs, is_rec || typ_rec
+        | Rtag (_, false, []) -> assert false)
+      ([], false) row_fields
+  in
+  let constrs = List.rev constrs in
+  let v = Schema.variants ~loc ~as_string:config.Attrs.variant_as_string ~compact_variants constrs in
+  v, is_rec
+
+(* Returns (schema_expression, is_recursive) *)
+let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = []) fields allow_extra_fields =
+  let fields, required, is_rec =
+    List.fold_left
+      (fun (fields, required, is_rec) ({ pld_name; pld_type; pld_loc = _loc; _ } as field) ->
+        let name =
+          match Attribute.get Attrs.jsonschema_key field with
+          | Some name -> name.txt
+          | None -> pld_name.txt
+        in
+        let drop_required =
+          Attribute.has_flag Attrs.jsonschema_option field
+          || Attribute.get Attrs.jsonschema_ld_default field |> Option.is_some
+        in
+        let type_def, field_rec =
+          match Attribute.get Attrs.jsonschema_ref field with
+          | Some def -> Schema.type_ref ~loc def.txt, false
+          | None ->
+          match pld_type with
+          | [%type: [%t? inner] option] ->
+            let s, r = schema_of_core_type ~config ~recursive_types inner in
+            [%expr option_jsonschema [%e s]], r
+          | _ -> schema_of_core_type ~config ~recursive_types pld_type
+        in
+        let type_def =
+          type_def
+          |> Schema.Annotation.add_description ~loc (Attrs.ld_description ~ocaml_doc:config.Attrs.ocaml_doc field)
+          |> Schema.Annotation.add_format ~loc (Attrs.jsonschema_ld_format, field) pld_type
+          |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_ld_maximum, field) pld_type
+          |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_ld_minimum, field) pld_type
+          |> Schema.Annotation.add_default ~loc (Attrs.jsonschema_ld_default, field) pld_type
+          |> Schema.Annotation.add_annotations ~loc ~core_type:pld_type (Attribute.get Attrs.jsonschema_ld_attrs field)
+        in
+        ( [%expr [%e estring ~loc name], [%e type_def]] :: fields,
+          (if drop_required then required else { txt = name; loc } :: required),
+          is_rec || field_rec ))
+      ([], [], false) fields
+  in
+  let required = List.map (fun { txt = name; loc } -> [%expr `String [%e estring ~loc name]]) required in
+  ( [%expr
+      `Assoc
+        [
+          "type", `String "object";
+          "properties", `Assoc [%e elist ~loc fields];
+          "required", `List [%e elist ~loc required];
+          "additionalProperties", `Bool [%e ebool ~loc allow_extra_fields];
+        ]],
+    is_rec )
+
+(* Returns (schema_expression, is_recursive, params_prefix) *)
+let schema_of_variants ~loc ~(config : Attrs.config) ?(recursive_types = []) ?(compact_variants = false) variants =
+  let variants, is_rec =
+    List.fold_left
+      (fun (variants, is_rec) ({ pcd_args; pcd_name = { txt = name; _ }; _ } as var) ->
+        let name =
+          match Attribute.get Attrs.jsonschema_variant_name var with
+          | Some name -> name.txt
+          | None -> name
+        in
+        let description_opt =
+          Option.map (fun d -> d.txt) (Attrs.cd_description ~ocaml_doc:config.Attrs.ocaml_doc var)
+        in
+        match pcd_args with
+        | Pcstr_record label_declarations ->
+          let allow_extra_fields = Attribute.get Attrs.jsonschema_cd_allow_extra_fields var |> Option.is_some in
+          let obj_schema, obj_rec =
+            schema_of_record ~loc ~config ~recursive_types label_declarations allow_extra_fields
+          in
+          `Tag (name, [ obj_schema ], description_opt) :: variants, is_rec || obj_rec
+        | Pcstr_tuple typs ->
+          let results = List.map (schema_of_core_type ~config ~recursive_types) typs in
+          let types = List.map fst results in
+          let typs_rec = List.exists snd results in
+          `Tag (name, types, description_opt) :: variants, is_rec || typs_rec)
+      ([], false) variants
+  in
+  let variants = List.rev variants in
+  let schema, params_prefix =
+    match config.Attrs.variant_as_string with
+    | true -> Schema.variants ~loc ~as_string:true variants, "_"
+    | false -> Schema.variants ~loc ~compact_variants variants, ""
+  in
+  schema, is_rec, params_prefix
+
+(* Returns (type_name, schema_expression, is_recursive, params, params_prefix) *)
+let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types type_decl =
+  let type_name = type_decl.ptype_name.txt in
+  let allow_extra_fields = Attribute.get Attrs.jsonschema_td_allow_extra_fields type_decl |> Option.is_some in
+  let params = List.map (fun tp -> (get_type_param_name tp).txt) type_decl.ptype_params in
+  match type_decl.ptype_kind with
+  | Ptype_variant variants ->
+    let compact_variants = Attribute.has_flag Attrs.jsonschema_td_compact_variants type_decl in
+    let schema, is_rec, params_prefix = schema_of_variants ~loc ~config ~recursive_types ~compact_variants variants in
+    type_name, schema, is_rec, params, params_prefix
+  | Ptype_record label_declarations ->
+    let schema, is_rec = schema_of_record ~loc ~config ~recursive_types label_declarations allow_extra_fields in
+    type_name, schema, is_rec, params, ""
+  | Ptype_abstract ->
+    (match type_decl.ptype_manifest with
+    | Some core_type ->
+      let compact_variants = Attribute.has_flag Attrs.jsonschema_td_compact_variants type_decl in
+      let schema, is_rec = schema_of_core_type ~config ~recursive_types ~compact_variants core_type in
+      type_name, schema, is_rec, params, ""
+    | None ->
+      let msg = "ppx_deriving_jsonschema: abstract type without manifest" in
+      type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false, params, "")
+  | Ptype_open ->
+    let msg = "ppx_deriving_jsonschema: open types not supported" in
+    type_name, [%expr [%ocaml.error [%e estring ~loc msg]]], false, params, ""
+
+let apply_defs ~loc = function
+  | `Rec (primary, defs) ->
+    let edv = evar ~loc "ppx_eds" in
+    let vname name = "ppx_body_" ^ name in
+    let pairs_expr =
+      elist ~loc (List.map (fun (name, _) -> [%expr [%e estring ~loc name], [%e evar ~loc (vname name)]]) defs)
+    in
+    let base_expr =
+      [%expr
+        `Assoc
+          [ "$defs", `Assoc ([%e pairs_expr] @ ![%e edv]); "$ref", `String [%e estring ~loc ("#/$defs/" ^ primary)] ]]
+    in
+    List.fold_right
+      (fun (name, s) acc ->
+        [%expr
+          let [%p ppat_var ~loc { txt = vname name; loc }] = [%e s] in
+          [%e acc]])
+      defs base_expr
+  | `NonRec schema ->
+    let edv = evar ~loc "ppx_eds" in
+    [%expr
+      let ppx_result = [%e schema] in
+      match ![%e edv] with
+      | [] -> ppx_result
+      | ppx_defs ->
+      match ppx_result with
+      | `Assoc ppx_pairs ->
+        `Assoc
+          (("$defs", `Assoc ppx_defs)
+          :: Stdlib.List.filter (fun (k, _) -> not (Stdlib.String.equal k "$defs")) ppx_pairs)
+      | other -> other]
+
+let str_type_decl ~ctxt ast flag_variant_as_string flag_polymorphic_variant_tuple flag_ocaml_doc =
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  let config : Attrs.config =
+    {
+      Attrs.variant_as_string = flag_variant_as_string;
+      Attrs.polymorphic_variant_tuple = flag_polymorphic_variant_tuple;
+      Attrs.ocaml_doc = flag_ocaml_doc;
+    }
+  in
+  match ast with
+  (* Single type declaration *)
+  | rec_flag, [ type_decl ] ->
+    let type_name = type_decl.ptype_name.txt in
+    let recursive_types =
+      match rec_flag with
+      | Recursive -> [ type_name ]
+      | Nonrecursive -> []
+    in
+    let _, raw_schema, is_rec, params, params_prefix = schema_of_type_decl ~loc ~config ~recursive_types type_decl in
+    let raw_schema =
+      raw_schema
+      |> Schema.Annotation.add_description ~loc (Attrs.td_description ~ocaml_doc:config.Attrs.ocaml_doc type_decl)
+      |> Schema.Annotation.add_annotations ~loc (Attribute.get Attrs.jsonschema_td_attrs type_decl)
+    in
+    let raw_schema =
+      Option.fold ~none:raw_schema
+        ~some:(fun core_type ->
+          Schema.Annotation.add_format ~loc (Attrs.jsonschema_td_format, type_decl) core_type raw_schema
+          |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_td_maximum, type_decl) core_type
+          |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_td_minimum, type_decl) core_type)
+        type_decl.ptype_manifest
+    in
+    let schema =
+      if is_rec then
+        [%expr
+          let ppx_eds = ref [] in
+          [%e apply_defs ~loc (`Rec (type_name, [ type_name, raw_schema ]))]]
+      else
+        [%expr
+          let ppx_eds = ref [] in
+          [%e apply_defs ~loc (`NonRec raw_schema)]]
+    in
+    let schema = wrap_type_params ~loc ~prefix:params_prefix params schema in
+    [ create_value ~loc type_name schema ]
+  (* Multiple type declarations (mutually recursive types) *)
+  | rec_flag, type_decls when List.length type_decls > 1 ->
+    let recursive_types =
+      match rec_flag with
+      | Recursive -> List.map (fun td -> td.ptype_name.txt) type_decls
+      | Nonrecursive -> []
+    in
+    let raw_results = List.map (schema_of_type_decl ~loc ~config ~recursive_types) type_decls in
+    let any_recursive = List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results in
+    if any_recursive then
+      List.map
+        (fun (name, raw, _, params, prefix) ->
+          let td = List.find (fun td -> td.ptype_name.txt = name) type_decls in
+          let raw =
+            raw |> Schema.Annotation.add_description ~loc (Attrs.td_description ~ocaml_doc:config.Attrs.ocaml_doc td)
+          in
+          let raw =
+            Option.fold ~none:raw
+              ~some:(fun core_type ->
+                Schema.Annotation.add_format ~loc (Attrs.jsonschema_td_format, td) core_type raw
+                |> Schema.Annotation.add_maximum ~loc (Attrs.jsonschema_td_maximum, td) core_type
+                |> Schema.Annotation.add_minimum ~loc (Attrs.jsonschema_td_minimum, td) core_type)
+              td.ptype_manifest
+          in
+          let defs = List.map (fun (n, r, _, _, _) -> n, if n = name then raw else r) raw_results in
+          let schema =
+            wrap_type_params ~loc ~prefix params
+              [%expr
+                let ppx_eds = ref [] in
+                [%e apply_defs ~loc (`Rec (name, defs))]]
+          in
+          create_value ~loc name schema)
+        raw_results
+    else
+      List.map
+        (fun (name, raw, _, params, prefix) ->
+          let td = List.find (fun td -> td.ptype_name.txt = name) type_decls in
+          let schema =
+            wrap_type_params ~loc ~prefix params
+              [%expr
+                let ppx_eds = ref [] in
+                [%e apply_defs ~loc (`NonRec raw)]]
+          in
+          let schema =
+            schema |> Schema.Annotation.add_description ~loc (Attrs.td_description ~ocaml_doc:config.Attrs.ocaml_doc td)
+          in
+          create_value ~loc name schema)
+        raw_results
+  | _, _ -> [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]
+
+let sig_type_decl ~ctxt ast _flag_variant_as_string _flag_polymorphic_variant_tuple _flag_ocaml_doc =
+  let jsonschema_t ~loc = ptyp_constr ~loc { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc } [] in
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  match ast with
+  | _, [ td ] ->
+    let typ = combinator_type_of_type_declaration td ~f:(fun ~loc _core_type -> jsonschema_t ~loc) in
+    let name = { txt = td.ptype_name.txt ^ "_jsonschema"; loc } in
+    [ psig_value ~loc (value_description ~loc ~name ~type_:typ ~prim:[]) ]
+  | _, type_decls when List.length type_decls > 1 ->
+    List.map
+      (fun td ->
+        let typ = combinator_type_of_type_declaration td ~f:(fun ~loc _core_type -> jsonschema_t ~loc) in
+        let name = { txt = td.ptype_name.txt ^ "_jsonschema"; loc } in
+        psig_value ~loc (value_description ~loc ~name ~type_:typ ~prim:[]))
+      type_decls
+  | _, _ ->
+    let ext = Location.error_extensionf ~loc "ppx_deriving_jsonschema: unsupported type" in
+    [ psig_extension ~loc ext [] ]
+
+(* Registration is performed explicitly by the melange-json ppx entry points
+   (ppx_deriving_json_native.ml / ppx_deriving_json_js.ml) rather than at module
+   load time, so the jsonschema deriver ships as part of melange-json[-native].ppx. *)
+let register () =
+  Deriving.add deriver_name
+    ~str_type_decl:(Deriving.Generator.V2.make ~attributes:Attrs.attributes (Attrs.args ()) str_type_decl)
+    ~sig_type_decl:(Deriving.Generator.V2.make ~attributes:Attrs.attributes (Attrs.args ()) sig_type_decl)

--- a/ppx/jsonschema/schema.ml
+++ b/ppx/jsonschema/schema.ml
@@ -1,0 +1,228 @@
+open Ppxlib
+open Ast_builder.Default
+
+let const ~loc value = [%expr `Assoc [ "const", `String [%e estring ~loc value] ]]
+
+let type_ref ~loc type_name =
+  let name = estring ~loc ("#/$defs/" ^ type_name) in
+  [%expr `Assoc [ "$ref", `String [%e name] ]]
+
+let type_def ~loc type_name = [%expr `Assoc [ "type", `String [%e estring ~loc type_name] ]]
+
+let oneOf ~loc values = [%expr `Assoc [ "oneOf", `List [%e elist ~loc values] ]]
+
+let anyOf ~loc values = [%expr `Assoc [ "anyOf", `List [%e elist ~loc values] ]]
+
+let tuple ~loc elements =
+  [%expr
+    `Assoc
+      [
+        "type", `String "array";
+        "prefixItems", `List [%e elist ~loc elements];
+        "unevaluatedItems", `Bool false;
+        "minItems", `Int [%e eint ~loc (List.length elements)];
+        "maxItems", `Int [%e eint ~loc (List.length elements)];
+      ]]
+
+let enum ~loc typ values =
+  match typ with
+  | Some typ -> [%expr `Assoc [ "type", `String [%e estring ~loc typ]; "enum", `List [%e elist ~loc values] ]]
+  | None -> [%expr `Assoc [ "enum", `List [%e elist ~loc values] ]]
+
+let enum_string ~loc values =
+  let values = List.map (fun name -> [%expr `String [%e estring ~loc name]]) values in
+  enum ~loc (Some "string") values
+
+let annotation ~loc (name, value) schema =
+  match schema with
+  | [%expr `Assoc [%e? fields]] -> [%expr `Assoc (([%e estring ~loc name], [%e value]) :: [%e fields])]
+  | s ->
+    [%expr
+      match [%e s] with
+      | `Assoc ppx_fields -> `Assoc (([%e estring ~loc name], [%e value]) :: ppx_fields)
+      | ppx_other -> ppx_other]
+let format ~loc format = annotation ~loc ("format", [%expr `String [%e estring ~loc format]])
+let maximum ~loc maximum = annotation ~loc ("maximum", maximum)
+let minimum ~loc minimum = annotation ~loc ("minimum", minimum)
+let default ~loc value = annotation ~loc ("default", value)
+let description ~loc description schema_expr =
+  annotation ~loc ("description", [%expr `String [%e estring ~loc description]]) schema_expr
+
+let variants ~loc ?(as_string = false) ?(compact_variants = false) constrs =
+  let opt_description ~loc desc schema =
+    match desc with
+    | Some d -> description ~loc d schema
+    | None -> schema
+  in
+  anyOf ~loc
+    (List.map
+       (function
+         | `Tag (name, typs, desc) ->
+           let schema =
+             if as_string then const ~loc name
+             else if compact_variants && typs = [] then const ~loc name
+             else tuple ~loc (const ~loc name :: typs)
+           in
+           opt_description ~loc desc schema
+         | `Inherit typ -> typ)
+       constrs)
+
+module Annotation = struct
+  let add_schema_attr (attr, node) f schema =
+    match Attribute.get attr node with
+    | Some v -> f v schema
+    | None -> schema
+
+  let add_format ~loc attr core_type =
+    add_schema_attr attr (fun fmt schema ->
+      match core_type with
+      | [%type: string] | [%type: bytes] | [%type: string option] | [%type: bytes option] -> format ~loc fmt.txt schema
+      | _ ->
+        Location.raise_errorf ~loc:core_type.ptyp_loc
+          "[@jsonschema.format] can only be applied to string or bytes types")
+
+  let add_maximum ~loc attr core_type =
+    add_schema_attr attr (fun expr schema ->
+      match core_type, expr.pexp_desc with
+      | [%type: int], Pexp_constant (Pconst_integer _)
+      | [%type: int32], Pexp_constant (Pconst_integer _)
+      | [%type: nativeint], Pexp_constant (Pconst_integer _) ->
+        maximum ~loc [%expr `Int [%e expr]] schema
+      | [%type: float], Pexp_constant (Pconst_float _) -> maximum ~loc [%expr `Float [%e expr]] schema
+      | _ -> Location.raise_errorf ~loc:core_type.ptyp_loc "[@jsonschema.maximum] can only be applied to numeric types")
+
+  let add_minimum ~loc attr core_type =
+    add_schema_attr attr (fun expr schema ->
+      match core_type, expr.pexp_desc with
+      | [%type: int], Pexp_constant (Pconst_integer _)
+      | [%type: int32], Pexp_constant (Pconst_integer _)
+      | [%type: nativeint], Pexp_constant (Pconst_integer _) ->
+        minimum ~loc [%expr `Int [%e expr]] schema
+      | [%type: float], Pexp_constant (Pconst_float _) -> minimum ~loc [%expr `Float [%e expr]] schema
+      | _ -> Location.raise_errorf ~loc:core_type.ptyp_loc "[@jsonschema.minimum] can only be applied to numeric types")
+
+  let rec serialize_expr ~loc ct default_value_expr =
+    match ct with
+    | [%type: int] | [%type: int32] | [%type: nativeint] -> [%expr `Int [%e default_value_expr]]
+    | [%type: float] -> [%expr `Float [%e default_value_expr]]
+    | [%type: string] | [%type: bytes] -> [%expr `String [%e default_value_expr]]
+    | [%type: bool] -> [%expr `Bool [%e default_value_expr]]
+    | [%type: [%t? t] option] ->
+      [%expr
+        match [%e default_value_expr] with
+        | None -> `Null
+        | Some ppx_opt_v -> [%e serialize_expr ~loc t [%expr ppx_opt_v]]]
+    | [%type: [%t? t] list] ->
+      [%expr
+        `List (Stdlib.List.map (fun ppx_item -> [%e serialize_expr ~loc t [%expr ppx_item]]) [%e default_value_expr])]
+    | [%type: [%t? t] array] ->
+      [%expr
+        `List
+          (Stdlib.Array.to_list
+             (Stdlib.Array.map (fun ppx_item -> [%e serialize_expr ~loc t [%expr ppx_item]]) [%e default_value_expr]))]
+    | { ptyp_desc = Ptyp_tuple types; _ } ->
+      let vars = List.mapi (fun i _ -> Printf.sprintf "ppx_tuple_%d" i) types in
+      let pats = List.map (fun v -> ppat_var ~loc { txt = v; loc }) vars in
+      let exprs = List.map2 (fun t v -> serialize_expr ~loc t (evar ~loc v)) types vars in
+      [%expr
+        match [%e default_value_expr] with
+        | [%p ppat_tuple ~loc pats] -> `List [%e elist ~loc exprs]]
+    | { ptyp_desc = Ptyp_var name; _ } -> [%expr [%e evar ~loc name] [%e default_value_expr]]
+    | { ptyp_desc = Ptyp_constr (id, args); _ } ->
+      let arg_serializers =
+        List.map
+          (fun arg ->
+            [%expr fun ppx_x -> Ppx_deriving_jsonschema_runtime.declassify [%e serialize_expr ~loc arg [%expr ppx_x]]])
+          args
+      in
+      let to_json_expr =
+        type_constr_conv ~loc id ~f:(fun s -> if String.equal s "t" then "to_json" else s ^ "_to_json") arg_serializers
+      in
+      [%expr Ppx_deriving_jsonschema_runtime.classify ([%e to_json_expr] [%e default_value_expr])]
+    | _ ->
+      Location.raise_errorf ~loc:ct.ptyp_loc
+        "[@jsonschema.default] cannot serialize this type. For non-primitive types, ensure a '<type>_to_json' function \
+         is in scope (e.g., add [@@deriving json] to the type definition)"
+
+  let add_default ~loc attr core_type =
+    add_schema_attr attr (fun expr schema ->
+      let json_value =
+        match expr.pexp_desc with
+        | Pexp_construct ({ txt = Lident "[]"; _ }, None) -> [%expr `List []]
+        | Pexp_construct ({ txt = Lident "None"; _ }, None) -> [%expr `Null]
+        | _ ->
+          let base_type =
+            match core_type with
+            | [%type: [%t? t] option] -> t
+            | t -> t
+          in
+          serialize_expr ~loc base_type expr
+      in
+      match schema with
+      | [%expr `Assoc [%e? fields]] -> [%expr `Assoc (("default", [%e json_value]) :: [%e fields])]
+      | s ->
+        [%expr
+          match [%e s] with
+          | `Assoc ppx_fields -> `Assoc (("default", [%e json_value]) :: ppx_fields)
+          | ppx_other -> ppx_other])
+
+  let add_description ~loc desc_opt schema =
+    match desc_opt with
+    | Some desc -> description ~loc desc.txt schema
+    | None -> schema
+
+  let add_annotations ~loc ?core_type attrs schema =
+    let require_core_type field =
+      match core_type with
+      | Some t -> t
+      | None ->
+        Location.raise_errorf ~loc
+          "[@jsonschema.attrs] '%s' requires a type context (use the individual [@jsonschema.%s] attribute instead)"
+          field field
+    in
+    match attrs with
+    | None -> schema
+    | Some expr ->
+    match expr.pexp_desc with
+    | Pexp_record (fields, None) ->
+      List.fold_left
+        (fun schema ({ txt = label; loc = label_loc }, value) ->
+          match label with
+          | Lident "description" ->
+            (match value.pexp_desc with
+            | Pexp_constant (Pconst_string (s, _, _)) -> description ~loc s schema
+            | _ ->
+              Location.raise_errorf ~loc:value.pexp_loc "[@jsonschema.attrs] 'description' must be a string literal")
+          | Lident "format" ->
+            let ct = require_core_type "format" in
+            (match value.pexp_desc with
+            | Pexp_constant (Pconst_string (s, _, _)) ->
+              (match ct with
+              | [%type: string] | [%type: bytes] | [%type: string option] | [%type: bytes option] ->
+                format ~loc s schema
+              | _ ->
+                Location.raise_errorf ~loc:ct.ptyp_loc
+                  "[@jsonschema.attrs] 'format' can only be applied to string types")
+            | _ -> Location.raise_errorf ~loc:value.pexp_loc "[@jsonschema.attrs] 'format' must be a string literal")
+          | Lident "maximum" ->
+            let ct = require_core_type "maximum" in
+            (match ct with
+            | [%type: int] | [%type: int32] | [%type: nativeint] -> maximum ~loc [%expr `Int [%e value]] schema
+            | [%type: float] -> maximum ~loc [%expr `Float [%e value]] schema
+            | _ ->
+              Location.raise_errorf ~loc:ct.ptyp_loc
+                "[@jsonschema.attrs] 'maximum' can only be applied to numeric types")
+          | Lident "minimum" ->
+            let ct = require_core_type "minimum" in
+            (match ct with
+            | [%type: int] | [%type: int32] | [%type: nativeint] -> minimum ~loc [%expr `Int [%e value]] schema
+            | [%type: float] -> minimum ~loc [%expr `Float [%e value]] schema
+            | _ ->
+              Location.raise_errorf ~loc:ct.ptyp_loc
+                "[@jsonschema.attrs] 'minimum' can only be applied to numeric types")
+          | Lident name -> Location.raise_errorf ~loc:label_loc "[@jsonschema.attrs] unknown field: '%s'" name
+          | _ -> Location.raise_errorf ~loc:label_loc "[@jsonschema.attrs] expected a simple field name")
+        schema fields
+    | _ ->
+      Location.raise_errorf ~loc:expr.pexp_loc "[@jsonschema.attrs] expects a record expression: { field = value; ... }"
+end

--- a/ppx/jsonschema/schema.mli
+++ b/ppx/jsonschema/schema.mli
@@ -1,0 +1,54 @@
+val const : loc:Warnings.loc -> string -> Ppxlib.expression
+val type_ref : loc:Warnings.loc -> string -> Ppxlib.expression
+val type_def : loc:Warnings.loc -> string -> Ppxlib.expression
+val oneOf : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
+val anyOf : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
+val tuple : loc:Warnings.loc -> Ppxlib.expression list -> Ppxlib.expression
+val enum : loc:Warnings.loc -> string option -> Ppxlib.expression list -> Ppxlib.expression
+val enum_string : loc:Warnings.loc -> string list -> Ppxlib.expression
+val annotation : loc:Warnings.loc -> string * Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
+val format : loc:Warnings.loc -> string -> Ppxlib.expression -> Ppxlib.expression
+val maximum : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
+val minimum : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
+val default : loc:Warnings.loc -> Ppxlib.expression -> Ppxlib.expression -> Ppxlib.expression
+val description : loc:Warnings.loc -> string -> Ppxlib.expression -> Ppxlib.expression
+val variants :
+  loc:Warnings.loc ->
+  ?as_string:bool ->
+  ?compact_variants:bool ->
+  [< `Inherit of Ppxlib.expression | `Tag of string * Ppxlib.expression list * string option ] list ->
+  Ppxlib.expression
+
+module Annotation : sig
+  val add_format :
+    loc:Warnings.loc ->
+    ('a, string Location.loc) Ppxlib.Attribute.t * 'a ->
+    Ppxlib.core_type ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+  val add_maximum :
+    loc:Warnings.loc ->
+    ('a, Ppxlib.expression) Ppxlib.Attribute.t * 'a ->
+    Ppxlib.core_type ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+  val add_minimum :
+    loc:Warnings.loc ->
+    ('a, Ppxlib.expression) Ppxlib.Attribute.t * 'a ->
+    Ppxlib.core_type ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+  val add_description : loc:Warnings.loc -> string Location.loc option -> Ppxlib.expression -> Ppxlib.expression
+  val add_default :
+    loc:Warnings.loc ->
+    ('a, Ppxlib.expression) Ppxlib.Attribute.t * 'a ->
+    Ppxlib.core_type ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+  val add_annotations :
+    loc:Warnings.loc ->
+    ?core_type:Ppxlib.core_type ->
+    Ppxlib.expression option ->
+    Ppxlib.expression ->
+    Ppxlib.expression
+end

--- a/ppx/jsonschema/test/.ocamlformat-ignore
+++ b/ppx/jsonschema/test/.ocamlformat-ignore
@@ -1,0 +1,1 @@
+*.expected.ml

--- a/ppx/jsonschema/test/README.md
+++ b/ppx/jsonschema/test/README.md
@@ -1,0 +1,74 @@
+# Test layout
+
+This directory has three roles:
+
+- snapshot the PPX expansion itself
+- snapshot the generated JSON Schemas on native
+- verify that Melange produces the same schema bundle
+
+## Files in `test/`
+
+- `shared/cases.ml`
+  - source of truth for the test case type definitions and helper values
+  - compiled natively and also copied into the Melange test build so both targets
+    exercise the same cases
+- `pp.ml`
+  - standalone native PPX driver used to snapshot expansion output
+- `pp_melange.ml`
+  - standalone Melange-flavoured PPX driver used to snapshot expansion output
+- `test.expected.ml`
+  - expected native PPX expansion for `shared/cases.ml`
+- `test.melange.expected.ml`
+  - expected Melange-flavoured PPX expansion for `shared/cases.ml`
+- `generate_schemas.ml`
+  - native entrypoint that prints the full schema snapshot
+- `test_schemas.expected.json`
+  - expected schema snapshot shared by native and Melange
+- `test_sig.t`
+  - cram test for signature rewriting
+
+## `test/shared/`
+
+Cross-target support code.
+
+- `cases.ml`
+  - source of truth for shared case definitions
+- `generate_schemas_cases.ml`
+  - lists which schemas from `cases.ml` are included in the snapshot bundle
+  - this is intentionally separate from `cases.ml`: `cases.ml` owns the type
+    definitions, while this file owns the snapshot selection/order
+- `schema_snapshot.ml`
+  - tiny JSON serializer for `Ppx_deriving_jsonschema_runtime.t`
+  - needed because Melange does not have `Yojson.Basic`
+
+## `test/melange/`
+
+Melange-only test entrypoints.
+
+- `generate_schemas.ml`
+  - emits JS that prints the shared schema snapshot
+- `tests.t`
+  - cram test that runs the emitted JS with Node and diffs it against
+    `../test_schemas.expected.json`
+
+## Native vs Melange
+
+Native uses the root `test/` stanzas in `test/dune`.
+Melange uses `test/melange/dune` and reuses the same cases from `shared/cases.ml`.
+
+The important distinction is:
+
+- native pretty-prints through `Yojson.Basic`
+- Melange prints through `test/shared/schema_snapshot.ml`
+
+The schema content should otherwise match.
+
+## Updating tests
+
+When adding a new case:
+
+1. add the type/helper to `shared/cases.ml`
+2. add the corresponding schema expression to `shared/generate_schemas_cases.ml`
+3. refresh expectations:
+   - `opam exec -- dune runtest --auto-promote`
+   - if needed, regenerate `test_schemas.expected.json` from `generate_schemas.exe`

--- a/ppx/jsonschema/test/dune
+++ b/ppx/jsonschema/test/dune
@@ -1,0 +1,101 @@
+; The jsonschema deriver now ships inside melange-json-native.ppx / melange-json.ppx,
+; so the standalone ppx drivers below only link those (plus melange.ppx for the
+; Melange-flavoured driver) rather than a separate ppx_deriving_jsonschema deriver.
+
+(executable
+ (name pp)
+ (modules pp)
+ (libraries ppxlib melange-json-native.ppx))
+
+(executable
+ (name pp_melange)
+ (modules pp_melange)
+ (libraries ppxlib melange-json.ppx melange.ppx))
+
+(rule
+ (targets test.actual.ml)
+ (deps
+  (:pp pp.exe)
+  (:input shared/cases.ml))
+ (action
+  (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
+
+(rule
+ (targets test.melange.actual.ml)
+ (deps
+  (:pp pp_melange.exe)
+  (:input shared/cases.ml))
+ (action
+  (run ./%{pp} -deriving-keep-w32 both --impl %{input} -o %{targets})))
+
+(rule
+ (alias runtest)
+ (action
+  (diff test.expected.ml test.actual.ml)))
+
+(rule
+ (alias runtest)
+ (action
+  (diff test.melange.expected.ml test.melange.actual.ml)))
+
+(copy_files shared/cases.ml)
+
+(copy_files shared/schema_snapshot.ml)
+
+(copy_files shared/generate_schemas_cases.ml)
+
+(library
+ (name schema_snapshot_support)
+ (modules schema_snapshot)
+ (wrapped false))
+
+(library
+ (name cases_support)
+ (modules cases)
+ (wrapped false)
+ (libraries melange-json-native melange-json-native.jsonschema)
+ (preprocess
+  (pps melange-json-native.ppx)))
+
+(library
+ (name generate_schemas_support)
+ (modules generate_schemas_cases)
+ (wrapped false)
+ (libraries
+  melange-json-native.jsonschema
+  schema_snapshot_support
+  cases_support))
+
+(cram
+ (deps %{exe:pp.exe} %{exe:pp_melange.exe}))
+
+; Wire test: encode sample values with [to_json] and validate them against the
+; generated schema using the external [check-jsonschema] CLI.
+
+(executable
+ (name wire)
+ (modules wire)
+ (libraries unix yojson melange-json-native melange-json-native.jsonschema)
+ (preprocess
+  (pps melange-json-native.ppx)))
+
+(cram
+ (applies_to wire)
+ (deps %{exe:wire.exe}))
+
+(executable
+ (name generate_schemas)
+ (modules generate_schemas)
+ (libraries yojson generate_schemas_support))
+
+(rule
+ (targets test_schemas.actual.json)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./generate_schemas.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff test_schemas.expected.json test_schemas.actual.json)))

--- a/ppx/jsonschema/test/generate_schemas.ml
+++ b/ppx/jsonschema/test/generate_schemas.ml
@@ -1,0 +1,4 @@
+let () =
+  print_endline
+    (Yojson.Basic.pretty_to_string
+       (Generate_schemas_cases.snapshot : Ppx_deriving_jsonschema_runtime.t :> Yojson.Basic.t))

--- a/ppx/jsonschema/test/melange/dune
+++ b/ppx/jsonschema/test/melange/dune
@@ -1,0 +1,19 @@
+(copy_files ../shared/cases.ml)
+
+(copy_files ../shared/schema_snapshot.ml)
+
+(copy_files ../shared/generate_schemas_cases.ml)
+
+(melange.emit
+ (target output)
+ (libraries melange-json melange-json.jsonschema)
+ (preprocess
+  (pps melange-json.ppx melange.ppx))
+ (module_systems
+  (commonjs js)))
+
+(cram
+ (deps
+  (alias melange)
+  ../test_schemas.expected.json
+  ./output/ppx/jsonschema/test/melange/generate_schemas.js))

--- a/ppx/jsonschema/test/melange/generate_schemas.ml
+++ b/ppx/jsonschema/test/melange/generate_schemas.ml
@@ -1,0 +1,1 @@
+let () = print_endline Generate_schemas_cases.snapshot_string

--- a/ppx/jsonschema/test/melange/tests.t
+++ b/ppx/jsonschema/test/melange/tests.t
@@ -1,0 +1,15 @@
+melange schemas
+  $ node ./output/ppx/jsonschema/test/melange/generate_schemas.js > test_schemas.actual.json
+  $ python3 - <<'EOF' > test_schemas.actual.pretty.json
+  > import json
+  > from pathlib import Path
+  > actual = Path("test_schemas.actual.json").read_text()
+  > actual = actual.replace("file://ppx/jsonschema/test/melange/cases.ml:", "file://ppx/jsonschema/test/cases.ml:")
+  > print(json.dumps(json.loads(actual), indent=2))
+  > EOF
+  $ python3 - <<'EOF' > test_schemas.expected.pretty.json
+  > import json
+  > from pathlib import Path
+  > print(json.dumps(json.loads(Path("../test_schemas.expected.json").read_text()), indent=2))
+  > EOF
+  $ diff -u test_schemas.expected.pretty.json test_schemas.actual.pretty.json

--- a/ppx/jsonschema/test/pp.ml
+++ b/ppx/jsonschema/test/pp.ml
@@ -1,0 +1,1 @@
+let () = Ppxlib.Driver.standalone ()

--- a/ppx/jsonschema/test/pp_melange.ml
+++ b/ppx/jsonschema/test/pp_melange.ml
@@ -1,0 +1,1 @@
+let () = Ppxlib.Driver.standalone ()

--- a/ppx/jsonschema/test/shared/cases.ml
+++ b/ppx/jsonschema/test/shared/cases.ml
@@ -1,0 +1,550 @@
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
+open Melange_json.Primitives
+
+let string_jsonschema = `Assoc [ "type", `String "string" ]
+let int_jsonschema = `Assoc [ "type", `String "integer" ]
+let bool_jsonschema = `Assoc [ "type", `String "boolean" ]
+module Mod1 = struct
+  type m_1 =
+    | A
+    | B
+  [@@deriving jsonschema]
+  module Mod2 = struct
+    type m_2 =
+      | C
+      | D
+    [@@deriving jsonschema]
+  end
+end
+type with_modules = {
+  m : Mod1.m_1;
+  m2 : Mod1.Mod2.m_2;
+}
+[@@deriving jsonschema]
+type kind =
+  | Success
+  | Error
+  | Skipped [@name "skipped"]
+[@@deriving jsonschema]
+type kind_as_string =
+  | Success
+  | Error
+  | Skipped [@name "skipped"]
+[@@deriving jsonschema ~variant_as_string]
+type poly_kind =
+  [ `Aaa
+  | `Bbb
+  | `Ccc [@name "ccc"]
+  ]
+[@@deriving jsonschema]
+type poly_kind_as_string =
+  [ `Aaa
+  | `Bbb
+  | `Ccc [@name "ccc"]
+  ]
+[@@deriving jsonschema ~variant_as_string]
+type poly_kind_with_payload =
+  [ `Aaa of int
+  | `Bbb
+  | `Ccc of string * bool [@name "ccc"]
+  ]
+[@@deriving jsonschema]
+type poly_kind_with_payload_as_string =
+  [ `Aaa of int
+  | `Bbb
+  | `Ccc of string * bool [@name "ccc"]
+  ]
+[@@deriving jsonschema ~variant_as_string]
+type poly_inherit =
+  [ `New_one
+  | `Second_one of int
+  | poly_kind
+  ]
+[@@deriving jsonschema]
+type poly_inherit_as_string =
+  [ `New_one
+  | `Second_one of int
+  | poly_kind_as_string
+  ]
+[@@deriving jsonschema ~variant_as_string]
+type event = {
+  date : float;
+  kind_f : kind;
+  comment : string;
+  opt : int option; [@key "opt_int"]
+  a : float array;
+  l : string list;
+  t : [ `Foo | `Bar | `Baz ];
+  c : char;
+  bunch_of_bytes : bytes;
+  string_ref : string ref;
+  unit : unit;
+  native_int : nativeint;
+}
+[@@deriving jsonschema]
+type recursive_record = {
+  a : int;
+  b : recursive_record list;
+}
+[@@deriving jsonschema]
+type recursive_variant =
+  | A of recursive_variant
+  | B
+[@@deriving jsonschema]
+type tree =
+  | Leaf
+  | Node of {
+      value : int;
+      left : tree;
+      right : tree;
+    }
+[@@deriving jsonschema]
+type non_recursive = {
+  x : int;
+  y : string;
+}
+[@@deriving jsonschema]
+type foo = { bar : bar option }
+and bar = { foo : foo option } [@@deriving jsonschema]
+type expr =
+  | Literal of int
+  | Binary of expr * expr
+  | Block of stmt list
+and stmt =
+  | ExprStmt of expr
+  | IfStmt of {
+      cond : expr;
+      then_ : stmt;
+      else_ : stmt option;
+    }
+[@@deriving jsonschema]
+type alpha = { x : int }
+and beta = { y : string } [@@deriving jsonschema]
+type node_a = {
+  b : node_b option;
+  c : node_c option;
+}
+and node_b = {
+  a : node_a option;
+  c : node_c option;
+}
+and node_c = {
+  a : node_a option;
+  b : node_b option;
+}
+[@@deriving jsonschema]
+type recursive_tuple =
+  | Leaf of int
+  | Branch of (recursive_tuple * recursive_tuple)
+[@@deriving jsonschema]
+type int_tree = tree [@@deriving jsonschema]
+type events = event list [@@deriving jsonschema]
+type eventss = event list list [@@deriving jsonschema]
+type event_comment = event * string [@@deriving jsonschema]
+type event_comments' = event_comment list [@@deriving jsonschema]
+type event_n = (event * int) list [@@deriving jsonschema]
+type events_array = events array [@@deriving jsonschema]
+type numbers = int list [@@deriving jsonschema]
+type opt = int option [@@deriving jsonschema]
+type using_m = { m : Mod1.m_1 } [@@deriving jsonschema]
+type 'param2 poly2 = C of 'param2 [@@deriving jsonschema ~variant_as_string]
+type tuple_with_variant = int * [ `A | `B [@name "second_cstr"] ] [@@deriving jsonschema]
+type player_scores = {
+  player : string;
+  scores : numbers; [@ref "numbers"] [@key "scores_ref"]
+}
+[@@deriving jsonschema]
+type address = {
+  street : string;
+  city : string;
+  zip : string;
+}
+[@@deriving jsonschema]
+type t = {
+  name : string;
+  age : int;
+  email : string option;
+  address : address;
+}
+[@@deriving jsonschema]
+type tt = {
+  name : string;
+  age : int;
+  email : string option;
+  home_address : address; [@ref "shared_address"]
+  work_address : address; [@ref "shared_address"]
+  retreat_address : address; [@ref "shared_address"]
+}
+[@@deriving jsonschema]
+type c = char [@@deriving jsonschema]
+type variant_inline_record =
+  | A of { a : int }
+  | B of { b : string }
+[@@deriving jsonschema ~variant_as_string]
+type inline_record_with_extra_fields =
+  | User of {
+      name : string;
+      email : string;
+    } [@jsonschema.allow_extra_fields]
+  | Guest of { ip : string }
+[@@deriving jsonschema]
+type variant_with_payload =
+  | A of int
+  | B
+  | C of int * string
+  | D of (int * string * bool)
+[@@deriving jsonschema ~variant_as_string]
+type t1 =
+  | Typ
+  | Class of string
+[@@deriving jsonschema]
+type t2 =
+  | Typ
+  | Class of string
+[@@deriving jsonschema ~variant_as_string]
+type t3 =
+  | Typ [@name "type"]
+  | Class of string [@name "class"]
+[@@deriving jsonschema]
+type t4 = int * string [@@deriving jsonschema]
+type t5 = [ `A of int * string * bool ] [@@deriving jsonschema]
+type t6 = [ `A of (int * string * bool) * float ] [@@deriving jsonschema]
+type t7 = A of int * string * bool [@@deriving jsonschema]
+type t8 = A of (int * string * bool) [@@deriving jsonschema]
+type t9 = A of (int * string * bool) * float [@@deriving jsonschema]
+type t10 = [ `A of int * string * bool ] [@@deriving jsonschema]
+type t11 = [ `B of int * string * bool ] [@@deriving jsonschema ~polymorphic_variant_tuple]
+type obj2 = { x : int } [@@deriving jsonschema] [@@jsonschema.allow_extra_fields]
+type obj1 = { obj2 : obj2 } [@@deriving jsonschema]
+type nested_obj = { obj1 : obj1 } [@@deriving jsonschema] [@@allow_extra_fields]
+type x_without_extra = { x : int } [@@deriving jsonschema] [@@allow_extra_fields]
+type x_with_extra = {
+  x : int;
+  y : int;
+}
+[@@deriving jsonschema] [@@allow_extra_fields]
+type 'url generic_link_traffic = {
+  title : string option;
+  url : 'url;
+}
+[@@deriving jsonschema]
+type string_link_traffic = string generic_link_traffic [@@deriving jsonschema]
+type 'a poly_variant =
+  | A
+  | B of 'a
+[@@deriving jsonschema]
+type ('a, 'b) multi_param = {
+  first : 'a;
+  second : 'b;
+  label : string;
+}
+[@@deriving jsonschema]
+type 'a param_list = 'a list [@@deriving jsonschema]
+type ('a, 'b) either =
+  | Left of 'a
+  | Right of 'b
+[@@deriving jsonschema]
+type ('a, 'b) either_alias = ('a, 'b) either [@@deriving jsonschema]
+type ('a, 'b) direction =
+  | North
+  | South
+[@@deriving jsonschema ~variant_as_string]
+type tool_params = {
+  query : string; [@jsonschema.description "The search query to execute"]
+  max_results : int; [@jsonschema.description "Maximum number of results to return"]
+}
+[@@deriving jsonschema]
+type described_record = {
+  name : string; [@jsonschema.description "The user's full name"]
+  age : int option; [@jsonschema.option] [@jsonschema.description "The user's age"]
+}
+[@@deriving jsonschema] [@@jsonschema.description "A user object"]
+type with_key_and_desc = {
+  opt : int option; [@key "opt_int"] [@jsonschema.option] [@jsonschema.description "An optional integer"]
+}
+[@@deriving jsonschema]
+type described_variant =
+  | Plain [@jsonschema.description "No payload"]
+  | With_int of int [@jsonschema.description "Single integer tag"]
+  | Pair of string * int [@jsonschema.description "String and int"]
+  | Description_value of (string[@jsonschema.description "A string value"])
+[@@deriving jsonschema]
+type described_variant_inline_record =
+  | Point of {
+      x : int;
+      y : int;
+    } [@jsonschema.description "A 2D point"]
+[@@deriving jsonschema]
+type described_variant_string =
+  | A [@jsonschema.description "First choice"]
+  | B [@jsonschema.description "Second choice"]
+[@@deriving jsonschema ~variant_as_string]
+
+(* The [~ocaml_doc] flag opts into using [(** ... *)] doc comments as a
+   fallback for [@jsonschema.description]. Without the flag, doc comments are
+   ignored (see [doc_comment_disabled] below). *)
+
+(** A user object *)
+type doc_comment_record = {
+  name : string;  (** The user's full name *)
+  age : int;  (** The user's age *)
+}
+[@@deriving jsonschema ~ocaml_doc]
+
+(* Without the [~ocaml_doc] flag, doc comments are not turned into descriptions. *)
+
+(** A user object *)
+type doc_comment_disabled = { name : string  (** The user's full name *) } [@@deriving jsonschema]
+
+(* Explicit [@jsonschema.description] wins over an ocaml.doc comment on the same node. *)
+type doc_comment_override = { field : string [@jsonschema.description "explicit wins"]  (** ocaml.doc loses *) }
+[@@deriving jsonschema ~ocaml_doc]
+
+type doc_comment_variant =
+  | Plain  (** No payload *)
+  | With_int of int  (** Single integer tag *)
+[@@deriving jsonschema ~ocaml_doc]
+
+type doc_comment_core_type = (string[@ocaml.doc " A string alias "]) [@@deriving jsonschema ~ocaml_doc]
+
+type doc_attribute_alias = (string[@doc " Alias fallback "]) [@@deriving jsonschema ~ocaml_doc]
+(* Multi-line doc comments are preserved as-is apart from a [String.trim] on the
+   outermost whitespace. Internal newlines and indentation remain in the
+   generated description. *)
+
+[@@@ocamlformat "disable"]
+type doc_comment_multiline = {
+  name : string;  (** The user's full name.
+          Must be non-empty and under 100 characters. *)
+}
+[@@deriving jsonschema ~ocaml_doc]
+[@@@ocamlformat "enable"]
+
+type doc_comment_poly_variant =
+  [ `Plain  (** No payload *)
+  | `With_int of int  (** Single integer tag *)
+  ]
+[@@deriving jsonschema ~ocaml_doc]
+
+(* Multiple hand-written [@ocaml.doc] / [@doc] attributes on the same node are
+   joined into a single description with a blank-line separator. *)
+type doc_comment_multiple = (string[@ocaml.doc " first block "] [@ocaml.doc " second block "] [@doc " third block "])
+[@@deriving jsonschema ~ocaml_doc]
+
+(* Explicit [@jsonschema.description] on a polymorphic variant tag takes precedence. *)
+type doc_comment_poly_variant_override = [ `Tagged [@jsonschema.description "explicit wins"]  (** ocaml.doc loses *) ]
+[@@deriving jsonschema ~ocaml_doc]
+
+type computation_result =
+  | Ok
+  | Err of string
+[@@deriving jsonschema] [@@jsonschema.description "Either success or an error message string"]
+type nullable_fields = {
+  plain : string option;
+  drop_simple : string option; [@jsonschema.option]
+  drop_complex : int list option; [@jsonschema.option]
+}
+[@@deriving jsonschema]
+type melange_json_defaults = {
+  required_value : int;
+  option_value : string option; [@option]
+  option_default_none : string; [@default None]
+  default_none : string; [@default None]
+  default_value : string; [@default "-"]
+  dropped_option : int option; [@option] [@drop_default]
+  dropped_default : int list; [@default []] [@drop_default]
+  custom_drop_default : float; [@default 0.0] [@drop_default Float.equal]
+}
+[@@deriving jsonschema]
+type composing_type = string
+let composing_type_jsonschema = `Assoc [ "type", `String "string"; "description", `String "A string" ]
+type composing_record = { composing_type : composing_type option [@jsonschema.option] } [@@deriving jsonschema]
+type with_format = string [@@jsonschema.format "date-time"] [@@deriving jsonschema]
+type with_format_record = { with_format : string [@jsonschema.format "date-time"] } [@@deriving jsonschema]
+type with_format_variant =
+  | A of (string[@jsonschema.format "date-time"] [@jsonschema.description "A date-time string"])
+  | B
+[@@deriving jsonschema]
+type 'a grade' =
+  | A of 'a
+  | B of ('a grade' * 'a grade')
+  | C
+type 'a grade = 'a grade' =
+  | A of 'a
+  | B of ('a grade * 'a grade)
+  | C
+[@@deriving jsonschema]
+type self_ref = { children : self_ref list } [@@deriving jsonschema]
+type two_self_refs = {
+  a : self_ref;
+  b : self_ref;
+}
+[@@deriving jsonschema]
+type ('atom, 'group_atom) filter =
+  | Atom of 'atom
+  | Group of ('atom, 'group_atom) filter list * 'group_atom
+[@@deriving jsonschema]
+type ('atom, 'group_atom) bool_filter =
+  | BoolAtom of ('atom, 'group_atom) filter
+  | BoolFilterGroup of ('atom, 'group_atom) bool_filter list
+[@@deriving jsonschema]
+type 'a rec_wrapper =
+  | RWrap of 'a
+  | RNested of 'a rec_wrapper
+[@@deriving jsonschema]
+type outer_rec =
+  | ORLeaf of int
+  | ORNode of outer_rec rec_wrapper
+[@@deriving jsonschema]
+type with_maximum = int [@@jsonschema.maximum 100] [@@deriving jsonschema]
+type with_maximum_record = { field : int [@jsonschema.maximum 100] } [@@deriving jsonschema]
+type attrs_core_type =
+  (int[@jsonschema.attrs { maximum = 100; minimum = 0; description = "Integer percentage value (0-100 inclusive)" }])
+[@@deriving jsonschema]
+type attrs_record = {
+  score : int; [@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }]
+  label : string; [@jsonschema.attrs { format = "date-time"; description = "An ISO date-time" }]
+}
+[@@deriving jsonschema]
+type attrs_type_decl = int [@@jsonschema.attrs { description = "A plain integer" }] [@@deriving jsonschema]
+type minimum_core_type_int = (int[@jsonschema.minimum 0] [@jsonschema.maximum 100]) [@@deriving jsonschema]
+type minimum_core_type_float = (float[@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0]) [@@deriving jsonschema]
+type minimum_maximum_record = {
+  score : int; [@jsonschema.minimum 0] [@jsonschema.maximum 100]
+  ratio : float; [@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0]
+}
+[@@deriving jsonschema]
+type minimum_maximum_type_decl_int = int [@@jsonschema.minimum 0] [@@jsonschema.maximum 255] [@@deriving jsonschema]
+type minimum_maximum_type_decl_float = float
+[@@jsonschema.minimum 0.0] [@@jsonschema.maximum 1.0] [@@deriving jsonschema]
+type minimum_maximum_variant =
+  | Percentage of (int[@jsonschema.minimum 0] [@jsonschema.maximum 100])
+  | Factor of (float[@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0])
+[@@deriving jsonschema]
+type variant_for_default =
+  | A
+  | B
+[@@deriving to_json, jsonschema]
+
+type 'a range = {
+  from : 'a;
+  to_ : 'a; [@key "to"]
+}
+[@@deriving to_json, jsonschema]
+
+type record_for_default = { score : int option } [@@deriving to_json, jsonschema]
+
+type default_value = {
+  score : int option; [@default 0]
+  label : string; [@jsonschema.default "default"]
+  speed : float; [@jsonschema.default 100.0]
+  is_active : bool; [@jsonschema.default false]
+  pair : int * string; [@jsonschema.default 1, "hello"]
+  pairs : (string * string option) list; [@default [ "a", None; "b", Some "b" ]]
+  variant : variant_for_default; [@jsonschema.default A]
+  record : record_for_default; [@jsonschema.default { score = None }]
+  int_list : int list; [@jsonschema.default [ 1; 2; 3 ]]
+  empty_list : int list; [@jsonschema.default []]
+  range : int range; [@jsonschema.default { from = 0; to_ = 100 }]
+}
+[@@deriving jsonschema]
+
+module Status = struct
+  type t =
+    | Active
+    | Inactive
+  [@@deriving to_json, jsonschema]
+end
+type default_with_module_type = { status : Status.t [@jsonschema.default Status.Active] } [@@deriving jsonschema]
+
+(* Regression: a record value used as [@default] for a non-primitive field, where the record has
+   an [@option] [@drop_default] field set to None. In Melange, the generated [_to_json] emits the
+   field as [Js.Undefined.empty], so the JS object is [{ foo: undefined }]. Then
+   [Ppx_deriving_jsonschema_runtime.classify] mis-classifies [undefined] as a JSON object and
+   crashes with "Cannot convert undefined or null to object" while enumerating its entries. *)
+type inner_with_option_field = { foo : int option [@option] [@drop_default] } [@@deriving to_json, jsonschema]
+let empty_inner_with_option_field : inner_with_option_field = { foo = None }
+type outer_default_record_with_option = { inner : inner_with_option_field [@default empty_inner_with_option_field] }
+[@@deriving jsonschema]
+type compact_variants =
+  | A
+  | B
+  | C of int
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+type compact_poly_variants =
+  [ `Aaa
+  | `Bbb
+  | `Ccc of int
+  ]
+[@@deriving jsonschema] [@@jsonschema.compact_variants]
+
+(* Regression test: PPX-generated code must not depend on user-scope [List]/[String]/[Array].
+   Shadowing them with empty modules makes any unqualified reference (e.g. [List.filter])
+   in generated code fail to compile. This catches the same class of bug as `open Base`,
+   `open Containers`, etc. without pulling those libraries into the test deps. *)
+module Generated_code_must_qualify_stdlib = struct
+  module List = struct end
+  module String = struct end
+  module Array = struct end
+
+  type plain_variant_with_shadowed_stdlib =
+    | A
+    | B [@name "b"]
+  [@@deriving jsonschema]
+
+  type 'a wrapper_with_shadowed_stdlib =
+    | Wrap of 'a
+    | Nested of 'a wrapper_with_shadowed_stdlib
+  [@@deriving jsonschema]
+
+  type rec_using_wrapper_with_shadowed_stdlib =
+    | Leaf of int
+    | Node of rec_using_wrapper_with_shadowed_stdlib wrapper_with_shadowed_stdlib
+  [@@deriving jsonschema]
+
+  type record_with_default_with_shadowed_stdlib = {
+    items : int list; [@default [ 1; 2 ]]
+    items_a : int array; [@default [| 1; 2 |]]
+    name : string; [@default "x"]
+  }
+  [@@deriving jsonschema]
+
+  (* Non-recursive top-level type using a parametric recursive type as an arg:
+     exercises the [$id]-injection branch where the inner [$defs] gets a resource boundary. *)
+  type non_rec_using_wrapper_with_shadowed_stdlib = int wrapper_with_shadowed_stdlib [@@deriving jsonschema]
+end
+
+module Nonrec_type_alias = struct
+  type foo =
+    | A
+    | B
+  [@@deriving jsonschema]
+
+  module X = struct
+    type nonrec foo = foo [@@deriving jsonschema]
+  end
+end
+
+module Recursive_shapes = struct
+  type a = A of b
+  and b = int [@@deriving jsonschema]
+
+  type t =
+    | N
+    | S of t
+  [@@deriving jsonschema]
+
+  type 'a lst =
+    | Nil
+    | Cons of 'a * 'a lst
+  [@@deriving jsonschema]
+
+  type 'a tree =
+    | Leaf of 'a
+    | Node of 'a * 'a forest
+
+  and 'a forest =
+    | Empty
+    | Base of 'a tree * 'a forest
+  [@@deriving jsonschema]
+end

--- a/ppx/jsonschema/test/shared/generate_schemas_cases.ml
+++ b/ppx/jsonschema/test/shared/generate_schemas_cases.ml
@@ -1,0 +1,131 @@
+open Cases
+
+(* [shared/cases.ml] is the source of truth for the case definitions.
+   This module only enumerates which generated schemas are included in the shared
+   native/Melange snapshot. *)
+
+let schemas =
+  [
+    Ppx_deriving_jsonschema_runtime.json_schema Mod1.m_1_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Mod1.Mod2.m_2_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema with_modules_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema kind_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema kind_as_string_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema poly_kind_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema poly_kind_as_string_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema poly_kind_with_payload_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema poly_kind_with_payload_as_string_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema poly_inherit_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema poly_inherit_as_string_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema event_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema recursive_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema recursive_variant_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema tree_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema non_recursive_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema foo_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema bar_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema expr_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema alpha_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema beta_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema node_a_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema recursive_tuple_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema int_tree_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema events_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema eventss_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema event_comment_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema event_comments'_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema event_n_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema events_array_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema numbers_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema opt_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema using_m_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (poly2_jsonschema int_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema tuple_with_variant_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema ~id:"https://ahrefs.com/schemas/player_scores" ~title:"Player scores"
+      ~description:"Object representing player scores"
+      ~definitions:[ "numbers", numbers_jsonschema ]
+      player_scores_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema ~definitions:[ "shared_address", address_jsonschema ] tt_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema c_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema variant_inline_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema inline_record_with_extra_fields_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema variant_with_payload_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t1_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t2_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t3_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t4_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t5_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t6_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t7_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t8_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t9_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t10_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema t11_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema nested_obj_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema x_without_extra_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (generic_link_traffic_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema string_link_traffic_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (poly_variant_jsonschema int_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (multi_param_jsonschema int_jsonschema bool_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (param_list_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (either_jsonschema int_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (either_alias_jsonschema int_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (direction_jsonschema int_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema tool_params_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema described_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema with_key_and_desc_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema described_variant_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema described_variant_inline_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema described_variant_string_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_disabled_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_override_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_variant_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_core_type_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_attribute_alias_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_multiline_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_poly_variant_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_multiple_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema doc_comment_poly_variant_override_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema computation_result_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema nullable_fields_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema melange_json_defaults_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema composing_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema with_format_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema with_format_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema with_format_variant_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (grade_jsonschema int_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema two_self_refs_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (filter_jsonschema int_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema outer_rec_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (bool_filter_jsonschema int_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema with_maximum_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema with_maximum_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema attrs_core_type_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema attrs_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema attrs_type_decl_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema minimum_core_type_int_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema minimum_core_type_float_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema minimum_maximum_record_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema minimum_maximum_type_decl_int_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema minimum_maximum_type_decl_float_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema minimum_maximum_variant_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema default_value_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema default_with_module_type_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema outer_default_record_with_option_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema compact_variants_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema compact_poly_variants_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.foo_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Nonrec_type_alias.X.foo_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Recursive_shapes.a_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Recursive_shapes.b_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema Recursive_shapes.t_jsonschema;
+    Ppx_deriving_jsonschema_runtime.json_schema (Recursive_shapes.lst_jsonschema int_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (Recursive_shapes.tree_jsonschema string_jsonschema);
+    Ppx_deriving_jsonschema_runtime.json_schema (Recursive_shapes.forest_jsonschema string_jsonschema);
+  ]
+
+let snapshot = `Assoc [ "$schema", `String Ppx_deriving_jsonschema_runtime.schema_version; "oneOf", `List schemas ]
+
+let snapshot_string = Schema_snapshot.json_to_string snapshot

--- a/ppx/jsonschema/test/shared/schema_snapshot.ml
+++ b/ppx/jsonschema/test/shared/schema_snapshot.ml
@@ -1,0 +1,23 @@
+(* Shared schema snapshots are built as [Ppx_deriving_jsonschema_runtime.t] so the
+   same OCaml code can be reused by native tests and Melange tests.
+
+   Native tests can coerce that type to [Yojson.Basic.t] at the printing boundary,
+   but Melange has no [Yojson.Basic]. We therefore keep a tiny target-neutral JSON
+   serializer here so both targets can print the exact same shared snapshot value. *)
+
+let float_to_json_string f =
+  let s = string_of_float f in
+  if String.ends_with ~suffix:"." s then s ^ "0"
+  else if String.contains s '.' || String.contains s 'e' || String.contains s 'E' then s
+  else s ^ ".0"
+
+let rec json_to_string = function
+  | `Null -> "null"
+  | `String s -> Printf.sprintf "%S" s
+  | `Float f -> float_to_json_string f
+  | `Int i -> string_of_int i
+  | `Bool b -> if b then "true" else "false"
+  | `List xs -> "[" ^ String.concat "," (List.map json_to_string xs) ^ "]"
+  | `Assoc fields ->
+    let field_to_string (key, value) = Printf.sprintf "%S:%s" key (json_to_string value) in
+    "{" ^ String.concat "," (List.map field_to_string fields) ^ "}"

--- a/ppx/jsonschema/test/test.expected.ml
+++ b/ppx/jsonschema/test/test.expected.ml
@@ -1,0 +1,5018 @@
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
+open Melange_json.Primitives
+let string_jsonschema = `Assoc [("type", (`String "string"))]
+let int_jsonschema = `Assoc [("type", (`String "integer"))]
+let bool_jsonschema = `Assoc [("type", (`String "boolean"))]
+module Mod1 =
+  struct
+    type m_1 =
+      | A 
+      | B [@@deriving jsonschema]
+    include
+      struct
+        let m_1_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "B"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    module Mod2 =
+      struct
+        type m_2 =
+          | C 
+          | D [@@deriving jsonschema]
+        include
+          struct
+            let m_2_jsonschema =
+              let ppx_eds = ref [] in
+              let ppx_result =
+                `Assoc
+                  [("anyOf",
+                     (`List
+                        [`Assoc
+                           [("type", (`String "array"));
+                           ("prefixItems",
+                             (`List [`Assoc [("const", (`String "C"))]]));
+                           ("unevaluatedItems", (`Bool false));
+                           ("minItems", (`Int 1));
+                           ("maxItems", (`Int 1))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List [`Assoc [("const", (`String "D"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 1));
+                          ("maxItems", (`Int 1))]]))] in
+              match !ppx_eds with
+              | [] -> ppx_result
+              | ppx_defs ->
+                  (match ppx_result with
+                   | `Assoc ppx_pairs ->
+                       `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) ->
+                               not (Stdlib.String.equal k "$defs")) ppx_pairs))
+                   | other -> other)[@@warning "-32-39"]
+          end[@@ocaml.doc "@inline"][@@merlin.hide ]
+      end
+  end
+type with_modules = {
+  m: Mod1.m_1 ;
+  m2: Mod1.Mod2.m_2 }[@@deriving jsonschema]
+include
+  struct
+    let with_modules_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("m2",
+                  ((match Mod1.Mod2.m_2_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:21")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)));
+               ("m",
+                 ((match Mod1.m_1_jsonschema with
+                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://shared/cases.ml:20"))
+                         ::
+                         (Stdlib.List.filter
+                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                            pairs))
+                   | other -> other)))]));
+          ("required", (`List [`String "m2"; `String "m"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type kind =
+  | Success 
+  | Error 
+  | Skipped [@name "skipped"][@@deriving jsonschema]
+include
+  struct
+    let kind_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Success"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Error"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "skipped"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type kind_as_string =
+  | Success 
+  | Error 
+  | Skipped [@name "skipped"][@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let kind_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Success"))];
+                `Assoc [("const", (`String "Error"))];
+                `Assoc [("const", (`String "skipped"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving jsonschema]
+include
+  struct
+    let poly_kind_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Aaa"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Bbb"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "ccc"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind_as_string = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving
+                                                                  jsonschema
+                                                                    ~variant_as_string]
+include
+  struct
+    let poly_kind_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc [("const", (`String "ccc"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind_with_payload =
+  [ `Aaa of int  | `Bbb  | `Ccc of (string * bool) [@name "ccc"]][@@deriving
+                                                                   jsonschema]
+include
+  struct
+    let poly_kind_with_payload_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Aaa"))]; int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Bbb"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "ccc"))];
+                       string_jsonschema;
+                       bool_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind_with_payload_as_string =
+  [ `Aaa of int  | `Bbb  | `Ccc of (string * bool) [@name "ccc"]][@@deriving
+                                                                   jsonschema
+                                                                    ~variant_as_string]
+include
+  struct
+    let poly_kind_with_payload_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc [("const", (`String "ccc"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_inherit = [ `New_one  | `Second_one of int  | poly_kind][@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let poly_inherit_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "New_one"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Second_one"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                (match poly_kind_jsonschema with
+                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://shared/cases.ml:61"))
+                       ::
+                       (Stdlib.List.filter
+                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                          pairs))
+                 | other -> other)]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_inherit_as_string =
+  [ `New_one  | `Second_one of int  | poly_kind_as_string][@@deriving
+                                                            jsonschema
+                                                              ~variant_as_string]
+include
+  struct
+    let poly_inherit_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "New_one"))];
+                `Assoc [("const", (`String "Second_one"))];
+                (match poly_kind_as_string_jsonschema with
+                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://shared/cases.ml:67"))
+                       ::
+                       (Stdlib.List.filter
+                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                          pairs))
+                 | other -> other)]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event =
+  {
+  date: float ;
+  kind_f: kind ;
+  comment: string ;
+  opt: int option [@key "opt_int"];
+  a: float array ;
+  l: string list ;
+  t: [ `Foo  | `Bar  | `Baz ] ;
+  c: char ;
+  bunch_of_bytes: bytes ;
+  string_ref: string ref ;
+  unit: unit ;
+  native_int: nativeint }[@@deriving jsonschema]
+include
+  struct
+    let event_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("native_int", int_jsonschema);
+               ("unit", unit_jsonschema);
+               ("string_ref", string_jsonschema);
+               ("bunch_of_bytes", string_jsonschema);
+               ("c", char_jsonschema);
+               ("t",
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc
+                             [("type", (`String "array"));
+                             ("prefixItems",
+                               (`List [`Assoc [("const", (`String "Foo"))]]));
+                             ("unevaluatedItems", (`Bool false));
+                             ("minItems", (`Int 1));
+                             ("maxItems", (`Int 1))];
+                          `Assoc
+                            [("type", (`String "array"));
+                            ("prefixItems",
+                              (`List [`Assoc [("const", (`String "Bar"))]]));
+                            ("unevaluatedItems", (`Bool false));
+                            ("minItems", (`Int 1));
+                            ("maxItems", (`Int 1))];
+                          `Assoc
+                            [("type", (`String "array"));
+                            ("prefixItems",
+                              (`List [`Assoc [("const", (`String "Baz"))]]));
+                            ("unevaluatedItems", (`Bool false));
+                            ("minItems", (`Int 1));
+                            ("maxItems", (`Int 1))]]))]));
+               ("l", (list_jsonschema string_jsonschema));
+               ("a", (array_jsonschema float_jsonschema));
+               ("opt_int", (option_jsonschema int_jsonschema));
+               ("comment", string_jsonschema);
+               ("kind_f",
+                 ((match kind_jsonschema with
+                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://shared/cases.ml:72"))
+                         ::
+                         (Stdlib.List.filter
+                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                            pairs))
+                   | other -> other)));
+               ("date", float_jsonschema)]));
+          ("required",
+            (`List
+               [`String "native_int";
+               `String "unit";
+               `String "string_ref";
+               `String "bunch_of_bytes";
+               `String "c";
+               `String "t";
+               `String "l";
+               `String "a";
+               `String "opt_int";
+               `String "comment";
+               `String "kind_f";
+               `String "date"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type recursive_record = {
+  a: int ;
+  b: recursive_record list }[@@deriving jsonschema]
+include
+  struct
+    let recursive_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_recursive_record =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/recursive_record"))])));
+               ("a", int_jsonschema)]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("recursive_record", ppx_body_recursive_record)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/recursive_record"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type recursive_variant =
+  | A of recursive_variant 
+  | B [@@deriving jsonschema]
+include
+  struct
+    let recursive_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_recursive_variant =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("$ref", (`String "#/$defs/recursive_variant"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("recursive_variant", ppx_body_recursive_variant)] @
+                 (!ppx_eds))));
+        ("$ref", (`String "#/$defs/recursive_variant"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tree =
+  | Leaf 
+  | Node of {
+  value: int ;
+  left: tree ;
+  right: tree } [@@deriving jsonschema]
+include
+  struct
+    let tree_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_tree =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Leaf"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Node"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("right",
+                                 (`Assoc [("$ref", (`String "#/$defs/tree"))]));
+                              ("left",
+                                (`Assoc [("$ref", (`String "#/$defs/tree"))]));
+                              ("value", int_jsonschema)]));
+                         ("required",
+                           (`List
+                              [`String "right";
+                              `String "left";
+                              `String "value"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs", (`Assoc ([("tree", ppx_body_tree)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type non_recursive = {
+  x: int ;
+  y: string }[@@deriving jsonschema]
+include
+  struct
+    let non_recursive_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("y", string_jsonschema); ("x", int_jsonschema)]));
+          ("required", (`List [`String "y"; `String "x"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type foo = {
+  bar: bar option }
+and bar = {
+  foo: foo option }[@@deriving jsonschema]
+include
+  struct
+    let foo_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_foo =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("bar",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
+          ("required", (`List [`String "bar"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_bar =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("foo",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
+          ("required", (`List [`String "foo"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("foo", ppx_body_foo); ("bar", ppx_body_bar)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
+    let bar_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_foo =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("bar",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
+          ("required", (`List [`String "bar"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_bar =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("foo",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
+          ("required", (`List [`String "foo"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("foo", ppx_body_foo); ("bar", ppx_body_bar)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/bar"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type expr =
+  | Literal of int 
+  | Binary of expr * expr 
+  | Block of stmt list 
+and stmt =
+  | ExprStmt of expr 
+  | IfStmt of {
+  cond: expr ;
+  then_: stmt ;
+  else_: stmt option } [@@deriving jsonschema]
+include
+  struct
+    let expr_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_expr =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Literal"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Binary"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Block"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      let ppx_body_stmt =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ExprStmt"))];
+                        `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "IfStmt"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("else_",
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
+                              ("then_",
+                                (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
+                              ("cond",
+                                (`Assoc [("$ref", (`String "#/$defs/expr"))]))]));
+                         ("required",
+                           (`List
+                              [`String "else_";
+                              `String "then_";
+                              `String "cond"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("expr", ppx_body_expr); ("stmt", ppx_body_stmt)] @
+                 (!ppx_eds))));
+        ("$ref", (`String "#/$defs/expr"))][@@warning "-32-39"]
+    let stmt_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_expr =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Literal"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Binary"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Block"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      let ppx_body_stmt =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ExprStmt"))];
+                        `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "IfStmt"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("else_",
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
+                              ("then_",
+                                (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
+                              ("cond",
+                                (`Assoc [("$ref", (`String "#/$defs/expr"))]))]));
+                         ("required",
+                           (`List
+                              [`String "else_";
+                              `String "then_";
+                              `String "cond"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("expr", ppx_body_expr); ("stmt", ppx_body_stmt)] @
+                 (!ppx_eds))));
+        ("$ref", (`String "#/$defs/stmt"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type alpha = {
+  x: int }
+and beta = {
+  y: string }[@@deriving jsonschema]
+include
+  struct
+    let alpha_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+    let beta_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("y", string_jsonschema)]));
+          ("required", (`List [`String "y"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type node_a = {
+  b: node_b option ;
+  c: node_c option }
+and node_b = {
+  a: node_a option ;
+  c: node_c option }
+and node_c = {
+  a: node_a option ;
+  b: node_b option }[@@deriving jsonschema]
+include
+  struct
+    let node_a_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_node_a =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("b",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_b =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_c =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/node_a"))][@@warning "-32-39"]
+    let node_b_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_node_a =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("b",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_b =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_c =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/node_b"))][@@warning "-32-39"]
+    let node_c_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_node_a =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("b",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_b =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_c =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/node_c"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type recursive_tuple =
+  | Leaf of int 
+  | Branch of (recursive_tuple * recursive_tuple) [@@deriving jsonschema]
+include
+  struct
+    let recursive_tuple_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_recursive_tuple =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Leaf"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Branch"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc
+                                 [("$ref",
+                                    (`String "#/$defs/recursive_tuple"))];
+                              `Assoc
+                                [("$ref",
+                                   (`String "#/$defs/recursive_tuple"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 2));
+                         ("maxItems", (`Int 2))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("recursive_tuple", ppx_body_recursive_tuple)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/recursive_tuple"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type int_tree = tree[@@deriving jsonschema]
+include
+  struct
+    let int_tree_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match tree_jsonschema with
+        | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://shared/cases.ml:140")) ::
+              (Stdlib.List.filter
+                 (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type events = event list[@@deriving jsonschema]
+include
+  struct
+    let events_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (match event_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:141")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type eventss = event list list[@@deriving jsonschema]
+include
+  struct
+    let eventss_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (list_jsonschema
+             (match event_jsonschema with
+              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                  `Assoc (("$id", (`String "file://shared/cases.ml:142")) ::
+                    (Stdlib.List.filter
+                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                       pairs))
+              | other -> other)) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event_comment = (event * string)[@@deriving jsonschema]
+include
+  struct
+    let event_comment_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems",
+            (`List
+               [(match event_jsonschema with
+                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://shared/cases.ml:143"))
+                       ::
+                       (Stdlib.List.filter
+                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                          pairs))
+                 | other -> other);
+               string_jsonschema]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event_comments' = event_comment list[@@deriving jsonschema]
+include
+  struct
+    let event_comments'_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (match event_comment_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:144")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event_n = (event * int) list[@@deriving jsonschema]
+include
+  struct
+    let event_n_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (`Assoc
+             [("type", (`String "array"));
+             ("prefixItems",
+               (`List
+                  [(match event_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:145")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other);
+                  int_jsonschema]));
+             ("unevaluatedItems", (`Bool false));
+             ("minItems", (`Int 2));
+             ("maxItems", (`Int 2))]) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type events_array = events array[@@deriving jsonschema]
+include
+  struct
+    let events_array_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        array_jsonschema
+          (match events_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:146")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type numbers = int list[@@deriving jsonschema]
+include
+  struct
+    let numbers_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result = list_jsonschema int_jsonschema in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type opt = int option[@@deriving jsonschema]
+include
+  struct
+    let opt_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result = option_jsonschema int_jsonschema in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type using_m = {
+  m: Mod1.m_1 }[@@deriving jsonschema]
+include
+  struct
+    let using_m_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("m",
+                  ((match Mod1.m_1_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:149")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "m"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'param2 poly2 =
+  | C of 'param2 [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let poly2_jsonschema _param2 =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc [("anyOf", (`List [`Assoc [("const", (`String "C"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tuple_with_variant = (int * [ `A  | `B [@name "second_cstr"]])[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let tuple_with_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems",
+            (`List
+               [int_jsonschema;
+               `Assoc
+                 [("anyOf",
+                    (`List
+                       [`Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List [`Assoc [("const", (`String "A"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 1));
+                          ("maxItems", (`Int 1))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc [("const", (`String "second_cstr"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 1));
+                         ("maxItems", (`Int 1))]]))]]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type player_scores =
+  {
+  player: string ;
+  scores: numbers [@ref "numbers"][@key "scores_ref"]}[@@deriving jsonschema]
+include
+  struct
+    let player_scores_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("scores_ref",
+                  (`Assoc [("$ref", (`String "#/$defs/numbers"))]));
+               ("player", string_jsonschema)]));
+          ("required", (`List [`String "scores_ref"; `String "player"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type address = {
+  street: string ;
+  city: string ;
+  zip: string }[@@deriving jsonschema]
+include
+  struct
+    let address_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("zip", string_jsonschema);
+               ("city", string_jsonschema);
+               ("street", string_jsonschema)]));
+          ("required",
+            (`List [`String "zip"; `String "city"; `String "street"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t = {
+  name: string ;
+  age: int ;
+  email: string option ;
+  address: address }[@@deriving jsonschema]
+include
+  struct
+    let t_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("address",
+                  ((match address_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:167")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
+          ("required",
+            (`List
+               [`String "address";
+               `String "email";
+               `String "age";
+               `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tt =
+  {
+  name: string ;
+  age: int ;
+  email: string option ;
+  home_address: address [@ref "shared_address"];
+  work_address: address [@ref "shared_address"];
+  retreat_address: address [@ref "shared_address"]}[@@deriving jsonschema]
+include
+  struct
+    let tt_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("retreat_address",
+                  (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("work_address",
+                 (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("home_address",
+                 (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
+          ("required",
+            (`List
+               [`String "retreat_address";
+               `String "work_address";
+               `String "home_address";
+               `String "email";
+               `String "age";
+               `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type c = char[@@deriving jsonschema]
+include
+  struct
+    let c_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result = char_jsonschema in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type variant_inline_record =
+  | A of {
+  a: int } 
+  | B of {
+  b: string } [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let variant_inline_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type inline_record_with_extra_fields =
+  | User of {
+  name: string ;
+  email: string } [@jsonschema.allow_extra_fields ]
+  | Guest of {
+  ip: string } [@@deriving jsonschema]
+include
+  struct
+    let inline_record_with_extra_fields_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "User"))];
+                        `Assoc
+                          [("type", (`String "object"));
+                          ("properties",
+                            (`Assoc
+                               [("email", string_jsonschema);
+                               ("name", string_jsonschema)]));
+                          ("required",
+                            (`List [`String "email"; `String "name"]));
+                          ("additionalProperties", (`Bool true))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Guest"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties", (`Assoc [("ip", string_jsonschema)]));
+                         ("required", (`List [`String "ip"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type variant_with_payload =
+  | A of int 
+  | B 
+  | C of int * string 
+  | D of (int * string * bool) [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let variant_with_payload_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))];
+                `Assoc [("const", (`String "C"))];
+                `Assoc [("const", (`String "D"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t1 =
+  | Typ 
+  | Class of string [@@deriving jsonschema]
+include
+  struct
+    let t1_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Typ"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Class"))];
+                       string_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t2 =
+  | Typ 
+  | Class of string [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let t2_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Typ"))];
+                `Assoc [("const", (`String "Class"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t3 =
+  | Typ [@name "type"]
+  | Class of string [@name "class"][@@deriving jsonschema]
+include
+  struct
+    let t3_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "type"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "class"))];
+                       string_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t4 = (int * string)[@@deriving jsonschema]
+include
+  struct
+    let t4_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems", (`List [int_jsonschema; string_jsonschema]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t5 = [ `A of (int * string * bool) ][@@deriving jsonschema]
+include
+  struct
+    let t5_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t6 = [ `A of ((int * string * bool) * float) ][@@deriving jsonschema]
+include
+  struct
+    let t6_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))];
+                        float_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 3));
+                   ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t7 =
+  | A of int * string * bool [@@deriving jsonschema]
+include
+  struct
+    let t7_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t8 =
+  | A of (int * string * bool) [@@deriving jsonschema]
+include
+  struct
+    let t8_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t9 =
+  | A of (int * string * bool) * float [@@deriving jsonschema]
+include
+  struct
+    let t9_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))];
+                        float_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 3));
+                   ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t10 = [ `A of (int * string * bool) ][@@deriving jsonschema]
+include
+  struct
+    let t10_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t11 = [ `B of (int * string * bool) ][@@deriving
+                                            jsonschema
+                                              ~polymorphic_variant_tuple]
+include
+  struct
+    let t11_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "B"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type obj2 = {
+  x: int }[@@deriving jsonschema][@@jsonschema.allow_extra_fields ]
+include
+  struct
+    let obj2_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type obj1 = {
+  obj2: obj2 }[@@deriving jsonschema]
+include
+  struct
+    let obj1_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("obj2",
+                  ((match obj2_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:218")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "obj2"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_obj = {
+  obj1: obj1 }[@@deriving jsonschema][@@allow_extra_fields ]
+include
+  struct
+    let nested_obj_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("obj1",
+                  ((match obj1_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:219")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "obj1"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type x_without_extra = {
+  x: int }[@@deriving jsonschema][@@allow_extra_fields ]
+include
+  struct
+    let x_without_extra_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type x_with_extra = {
+  x: int ;
+  y: int }[@@deriving jsonschema][@@allow_extra_fields ]
+include
+  struct
+    let x_with_extra_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("y", int_jsonschema); ("x", int_jsonschema)]));
+          ("required", (`List [`String "y"; `String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'url generic_link_traffic = {
+  title: string option ;
+  url: 'url }[@@deriving jsonschema]
+include
+  struct
+    let generic_link_traffic_jsonschema url =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("url", url);
+               ("title", (option_jsonschema string_jsonschema))]));
+          ("required", (`List [`String "url"; `String "title"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type string_link_traffic = string generic_link_traffic[@@deriving jsonschema]
+include
+  struct
+    let string_link_traffic_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match generic_link_traffic_jsonschema string_jsonschema with
+        | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://shared/cases.ml:231")) ::
+              (Stdlib.List.filter
+                 (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a poly_variant =
+  | A 
+  | B of 'a [@@deriving jsonschema]
+include
+  struct
+    let poly_variant_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]; a]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) multi_param = {
+  first: 'a ;
+  second: 'b ;
+  label: string }[@@deriving jsonschema]
+include
+  struct
+    let multi_param_jsonschema a b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("label", string_jsonschema); ("second", b); ("first", a)]));
+          ("required",
+            (`List [`String "label"; `String "second"; `String "first"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a param_list = 'a list[@@deriving jsonschema]
+include
+  struct
+    let param_list_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result = list_jsonschema a in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) either =
+  | Left of 'a 
+  | Right of 'b [@@deriving jsonschema]
+include
+  struct
+    let either_jsonschema a b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Left"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Right"))]; b]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) either_alias = ('a, 'b) either[@@deriving jsonschema]
+include
+  struct
+    let either_alias_jsonschema a b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match either_jsonschema a b with
+        | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://shared/cases.ml:247")) ::
+              (Stdlib.List.filter
+                 (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) direction =
+  | North 
+  | South [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let direction_jsonschema _a _b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "North"))];
+                `Assoc [("const", (`String "South"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tool_params =
+  {
+  query: string [@jsonschema.description "The search query to execute"];
+  max_results: int
+    [@jsonschema.description "Maximum number of results to return"]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let tool_params_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("max_results",
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String "Maximum number of results to return"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("query",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description",
+                            (`String "The search query to execute"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "max_results"; `String "query"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_record =
+  {
+  name: string [@jsonschema.description "The user's full name"];
+  age: int option
+    [@jsonschema.option ][@jsonschema.description "The user's age"]}[@@deriving
+                                                                    jsonschema]
+[@@jsonschema.description "A user object"]
+include
+  struct
+    let described_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A user object"));
+          ("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("age",
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("name",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_key_and_desc =
+  {
+  opt: int option
+    [@key "opt_int"][@jsonschema.option ][@jsonschema.description
+                                           "An optional integer"]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let with_key_and_desc_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("opt_int",
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description", (`String "An optional integer"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_variant =
+  | Plain [@jsonschema.description "No payload"]
+  | With_int of int [@jsonschema.description "Single integer tag"]
+  | Pair of string * int [@jsonschema.description "String and int"]
+  | Description_value of ((string)[@jsonschema.description "A string value"]) 
+[@@deriving jsonschema]
+include
+  struct
+    let described_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                `Assoc
+                  [("description", (`String "String and int"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Pair"))];
+                       string_jsonschema;
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Description_value"))];
+                       (match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc
+                              (("description", (`String "A string value")) ::
+                              ppx_fields)
+                        | ppx_other -> ppx_other)]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_variant_inline_record =
+  | Point of {
+  x: int ;
+  y: int } [@jsonschema.description "A 2D point"][@@deriving jsonschema]
+include
+  struct
+    let described_variant_inline_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "A 2D point"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Point"))];
+                        `Assoc
+                          [("type", (`String "object"));
+                          ("properties",
+                            (`Assoc
+                               [("y", int_jsonschema); ("x", int_jsonschema)]));
+                          ("required", (`List [`String "y"; `String "x"]));
+                          ("additionalProperties", (`Bool false))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_variant_string =
+  | A [@jsonschema.description "First choice"]
+  | B [@jsonschema.description "Second choice"][@@deriving
+                                                 jsonschema
+                                                   ~variant_as_string]
+include
+  struct
+    let described_variant_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "First choice"));
+                   ("const", (`String "A"))];
+                `Assoc
+                  [("description", (`String "Second choice"));
+                  ("const", (`String "B"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_record =
+  {
+  name: string [@ocaml.doc " The user's full name "];
+  age: int [@ocaml.doc " The user's age "]}[@@ocaml.doc " A user object "]
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A user object"));
+          ("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("age",
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("name",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "age"; `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_disabled =
+  {
+  name: string [@ocaml.doc " The user's full name "]}[@@ocaml.doc
+                                                       " A user object "]
+[@@deriving jsonschema]
+include
+  struct
+    let doc_comment_disabled_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("name", string_jsonschema)]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_override =
+  {
+  field: string
+    [@jsonschema.description "explicit wins"][@ocaml.doc " ocaml.doc loses "]}
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_override_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("field",
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "explicit wins")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "field"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_variant =
+  | Plain [@ocaml.doc " No payload "]
+  | With_int of int [@ocaml.doc " Single integer tag "][@@deriving
+                                                         jsonschema
+                                                           ~ocaml_doc]
+include
+  struct
+    let doc_comment_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_core_type = ((string)[@ocaml.doc " A string alias "])
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_core_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A string alias")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_attribute_alias = ((string)[@doc " Alias fallback "])[@@deriving
+                                                                jsonschema
+                                                                  ~ocaml_doc]
+include
+  struct
+    let doc_attribute_alias_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "Alias fallback")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[@@@ocamlformat "disable"]
+type doc_comment_multiline =
+  {
+  name: string
+    [@ocaml.doc
+      " The user's full name.\n          Must be non-empty and under 100 characters. "]}
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_multiline_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("name",
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String
+                                "The user's full name.\n          Must be non-empty and under 100 characters."))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[@@@ocamlformat "enable"]
+type doc_comment_poly_variant =
+  [ `Plain [@ocaml.doc " No payload "]
+  | `With_int of int [@ocaml.doc " Single integer tag "]][@@deriving
+                                                           jsonschema
+                                                             ~ocaml_doc]
+include
+  struct
+    let doc_comment_poly_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_multiple =
+  ((string)[@ocaml.doc " first block "][@ocaml.doc " second block "][@doc
+                                                                    " third block "])
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_multiple_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "first block\n\nsecond block\n\nthird block"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_poly_variant_override =
+  [
+    `Tagged
+      [@jsonschema.description "explicit wins"][@ocaml.doc
+                                                 " ocaml.doc loses "]]
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_poly_variant_override_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "explicit wins"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Tagged"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type computation_result =
+  | Ok 
+  | Err of string [@@deriving jsonschema][@@jsonschema.description
+                                           "Either success or an error message string"]
+include
+  struct
+    let computation_result_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description",
+             (`String "Either success or an error message string"));
+          ("anyOf",
+            (`List
+               [`Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Ok"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+               `Assoc
+                 [("type", (`String "array"));
+                 ("prefixItems",
+                   (`List
+                      [`Assoc [("const", (`String "Err"))];
+                      string_jsonschema]));
+                 ("unevaluatedItems", (`Bool false));
+                 ("minItems", (`Int 2));
+                 ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nullable_fields =
+  {
+  plain: string option ;
+  drop_simple: string option [@jsonschema.option ];
+  drop_complex: int list option [@jsonschema.option ]}[@@deriving jsonschema]
+include
+  struct
+    let nullable_fields_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("drop_complex",
+                  (option_jsonschema (list_jsonschema int_jsonschema)));
+               ("drop_simple", (option_jsonschema string_jsonschema));
+               ("plain", (option_jsonschema string_jsonschema))]));
+          ("required", (`List [`String "plain"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type melange_json_defaults =
+  {
+  required_value: int ;
+  option_value: string option [@option ];
+  option_default_none: string [@default None];
+  default_none: string [@default None];
+  default_value: string [@default "-"];
+  dropped_option: int option [@option ][@drop_default ];
+  dropped_default: int list [@default []][@drop_default ];
+  custom_drop_default: float [@default 0.0][@drop_default Float.equal]}
+[@@deriving jsonschema]
+include
+  struct
+    let melange_json_defaults_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("custom_drop_default",
+                  ((match float_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("default", (`Float 0.0)) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("dropped_default",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("dropped_option", (option_jsonschema int_jsonschema));
+               ("default_value",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`String "-")) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("default_none",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("option_default_none",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("option_value", (option_jsonschema string_jsonschema));
+               ("required_value", int_jsonschema)]));
+          ("required", (`List [`String "required_value"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type composing_type = string
+let composing_type_jsonschema =
+  `Assoc
+    [("type", (`String "string")); ("description", (`String "A string"))]
+type composing_record =
+  {
+  composing_type: composing_type option [@jsonschema.option ]}[@@deriving
+                                                                jsonschema]
+include
+  struct
+    let composing_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("composing_type",
+                  (option_jsonschema
+                     (match composing_type_jsonschema with
+                      | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                          ->
+                          `Assoc
+                            (("$id", (`String "file://shared/cases.ml:361"))
+                            ::
+                            (Stdlib.List.filter
+                               (fun (k, _) ->
+                                  not (Stdlib.String.equal k "$id")) pairs))
+                      | other -> other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_format = string[@@jsonschema.format "date-time"][@@deriving
+                                                            jsonschema]
+include
+  struct
+    let with_format_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("format", (`String "date-time")) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_format_record =
+  {
+  with_format: string [@jsonschema.format "date-time"]}[@@deriving
+                                                         jsonschema]
+include
+  struct
+    let with_format_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("with_format",
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("format", (`String "date-time")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "with_format"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_format_variant =
+  | A of
+  ((string)[@jsonschema.format "date-time"][@jsonschema.description
+                                             "A date-time string"])
+  
+  | B [@@deriving jsonschema]
+include
+  struct
+    let with_format_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        (match match string_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc
+                                     (("description",
+                                        (`String "A date-time string"))
+                                     :: ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("format", (`String "date-time")) ::
+                               ppx_fields)
+                         | ppx_other -> ppx_other)]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a grade' =
+  | A of 'a 
+  | B of ('a grade' * 'a grade') 
+  | C 
+type 'a grade = 'a grade' =
+  | A of 'a 
+  | B of ('a grade * 'a grade) 
+  | C [@@deriving jsonschema]
+include
+  struct
+    let grade_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_body_grade =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "B"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc [("$ref", (`String "#/$defs/grade"))];
+                              `Assoc [("$ref", (`String "#/$defs/grade"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 2));
+                         ("maxItems", (`Int 2))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "C"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      `Assoc
+        [("$defs", (`Assoc ([("grade", ppx_body_grade)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/grade"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type self_ref = {
+  children: self_ref list }[@@deriving jsonschema]
+include
+  struct
+    let self_ref_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_self_ref =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("children",
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/self_ref"))])))]));
+          ("required", (`List [`String "children"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs", (`Assoc ([("self_ref", ppx_body_self_ref)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/self_ref"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type two_self_refs = {
+  a: self_ref ;
+  b: self_ref }[@@deriving jsonschema]
+include
+  struct
+    let two_self_refs_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  ((match self_ref_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:380")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)));
+               ("a",
+                 ((match self_ref_jsonschema with
+                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                       `Assoc
+                         (("$id", (`String "file://shared/cases.ml:379")) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                            pairs))
+                   | other -> other)))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('atom, 'group_atom) filter =
+  | Atom of 'atom 
+  | Group of ('atom, 'group_atom) filter list * 'group_atom [@@deriving
+                                                              jsonschema]
+include
+  struct
+    let filter_jsonschema atom group_atom =
+      let ppx_eds = ref [] in
+      let ppx_body_filter =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Atom"))]; atom]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Group"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/filter"))]);
+                       group_atom]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))]]))] in
+      `Assoc
+        [("$defs", (`Assoc ([("filter", ppx_body_filter)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/filter"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('atom, 'group_atom) bool_filter =
+  | BoolAtom of ('atom, 'group_atom) filter 
+  | BoolFilterGroup of ('atom, 'group_atom) bool_filter list [@@deriving
+                                                               jsonschema]
+include
+  struct
+    let bool_filter_jsonschema atom group_atom =
+      let ppx_eds = ref [] in
+      let ppx_body_bool_filter =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "BoolAtom"))];
+                        (match filter_jsonschema atom group_atom with
+                         | `Assoc pairs when
+                             Stdlib.List.mem_assoc "$defs" pairs ->
+                             `Assoc
+                               (("$id",
+                                  (`String "file://shared/cases.ml:388"))
+                               ::
+                               (Stdlib.List.filter
+                                  (fun (k, _) ->
+                                     not (Stdlib.String.equal k "$id")) pairs))
+                         | other -> other)]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "BoolFilterGroup"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/bool_filter"))])]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc ([("bool_filter", ppx_body_bool_filter)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/bool_filter"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a rec_wrapper =
+  | RWrap of 'a 
+  | RNested of 'a rec_wrapper [@@deriving jsonschema]
+include
+  struct
+    let rec_wrapper_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_body_rec_wrapper =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "RWrap"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "RNested"))];
+                       `Assoc [("$ref", (`String "#/$defs/rec_wrapper"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc ([("rec_wrapper", ppx_body_rec_wrapper)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/rec_wrapper"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type outer_rec =
+  | ORLeaf of int 
+  | ORNode of outer_rec rec_wrapper [@@deriving jsonschema]
+include
+  struct
+    let outer_rec_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_outer_rec =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ORLeaf"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "ORNode"))];
+                       (match rec_wrapper_jsonschema
+                                (`Assoc
+                                   [("$ref", (`String "#/$defs/outer_rec"))])
+                        with
+                        | `Assoc ppx_pairs ->
+                            (match Stdlib.List.assoc_opt "$defs" ppx_pairs
+                             with
+                             | Some (`Assoc ppx_defs) ->
+                                 (ppx_eds :=
+                                    ((!ppx_eds) @
+                                       (Stdlib.List.filter
+                                          (fun (n, _) ->
+                                             not
+                                               (Stdlib.List.mem_assoc n
+                                                  (!ppx_eds))) ppx_defs));
+                                  `Assoc
+                                    (Stdlib.List.filter
+                                       (fun (k, _) ->
+                                          not (Stdlib.String.equal k "$defs"))
+                                       ppx_pairs))
+                             | _ -> `Assoc ppx_pairs)
+                        | ppx_other -> ppx_other)]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc ([("outer_rec", ppx_body_outer_rec)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/outer_rec"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_maximum = int[@@jsonschema.maximum 100][@@deriving jsonschema]
+include
+  struct
+    let with_maximum_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match int_jsonschema with
+        | `Assoc ppx_fields -> `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_maximum_record = {
+  field: int [@jsonschema.maximum 100]}[@@deriving jsonschema]
+include
+  struct
+    let with_maximum_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("field",
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "field"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type attrs_core_type =
+  ((int)[@jsonschema.attrs
+          {
+            maximum = 100;
+            minimum = 0;
+            description = "Integer percentage value (0-100 inclusive)"
+          }])[@@deriving jsonschema]
+include
+  struct
+    let attrs_core_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other
+              with
+              | `Assoc ppx_fields ->
+                  `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "Integer percentage value (0-100 inclusive)"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type attrs_record =
+  {
+  score: int
+    [@jsonschema.attrs
+      { maximum = 100; minimum = 0; description = "Score out of 100" }];
+  label: string
+    [@jsonschema.attrs
+      { format = "date-time"; description = "An ISO date-time" }]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let attrs_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("label",
+                  ((match match string_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("format", (`String "date-time")) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "An ISO date-time"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("score",
+                 ((match match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("description", (`String "Score out of 100"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "label"; `String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type attrs_type_decl = int[@@jsonschema.attrs
+                            { description = "A plain integer" }][@@deriving
+                                                                  jsonschema]
+include
+  struct
+    let attrs_type_decl_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match int_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A plain integer")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_core_type_int =
+  ((int)[@jsonschema.minimum 0][@jsonschema.maximum 100])[@@deriving
+                                                           jsonschema]
+include
+  struct
+    let minimum_core_type_int_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_core_type_float =
+  ((float)[@jsonschema.minimum 0.0][@jsonschema.maximum 1.0])[@@deriving
+                                                               jsonschema]
+include
+  struct
+    let minimum_core_type_float_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_record =
+  {
+  score: int [@jsonschema.minimum 0][@jsonschema.maximum 100];
+  ratio: float [@jsonschema.minimum 0.0][@jsonschema.maximum 1.0]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let minimum_maximum_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("ratio",
+                  ((match match float_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("maximum", (`Float 1.0)) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("score",
+                 ((match match int_jsonschema with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "ratio"; `String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_type_decl_int = int[@@jsonschema.minimum 0][@@jsonschema.maximum
+                                                                  255]
+[@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_type_decl_int_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 255)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_type_decl_float = float[@@jsonschema.minimum 0.0]
+[@@jsonschema.maximum 1.0][@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_type_decl_float_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_variant =
+  | Percentage of ((int)[@jsonschema.minimum 0][@jsonschema.maximum 100]) 
+  | Factor of ((float)[@jsonschema.minimum 0.0][@jsonschema.maximum 1.0]) 
+[@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Percentage"))];
+                        (match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other)]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Factor"))];
+                       (match match float_jsonschema with
+                              | `Assoc ppx_fields ->
+                                  `Assoc (("maximum", (`Float 1.0)) ::
+                                    ppx_fields)
+                              | ppx_other -> ppx_other
+                        with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                        | ppx_other -> ppx_other)]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type variant_for_default =
+  | A 
+  | B [@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec variant_for_default_to_json =
+      (fun x ->
+         match x with | A -> `List [`String "A"] | B -> `List [`String "B"] : 
+      variant_for_default -> Yojson.Basic.t)
+    let variant_for_default_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a range = {
+  from: 'a ;
+  to_: 'a [@key "to"]}[@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec range_to_json a_to_json =
+      (fun x ->
+         match x with
+         | { from = x_from; to_ = x_to_ } ->
+             `Assoc
+               (let bnds__001_ = [] in
+                let bnds__001_ = ("to", (a_to_json x_to_)) :: bnds__001_ in
+                let bnds__001_ = ("from", (a_to_json x_from)) :: bnds__001_ in
+                bnds__001_) : 'a range -> Yojson.Basic.t)
+    let range_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("to", a); ("from", a)]));
+          ("required", (`List [`String "to"; `String "from"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type record_for_default = {
+  score: int option }[@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec record_for_default_to_json =
+      (fun x ->
+         match x with
+         | { score = x_score } ->
+             `Assoc
+               (let bnds__002_ = [] in
+                let bnds__002_ =
+                  ("score", ((option_to_json int_to_json) x_score)) ::
+                  bnds__002_ in
+                bnds__002_) : record_for_default -> Yojson.Basic.t)
+    let record_for_default_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("score", (option_jsonschema int_jsonschema))]));
+          ("required", (`List [`String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type default_value =
+  {
+  score: int option [@default 0];
+  label: string [@jsonschema.default "default"];
+  speed: float [@jsonschema.default 100.0];
+  is_active: bool [@jsonschema.default false];
+  pair: (int * string) [@jsonschema.default (1, "hello")];
+  pairs: (string * string option) list
+    [@default [("a", None); ("b", (Some "b"))]];
+  variant: variant_for_default [@jsonschema.default A];
+  record: record_for_default [@jsonschema.default { score = None }];
+  int_list: int list [@jsonschema.default [1; 2; 3]];
+  empty_list: int list [@jsonschema.default []];
+  range: int range [@jsonschema.default { from = 0; to_ = 100 }]}[@@deriving
+                                                                   jsonschema]
+include
+  struct
+    let default_value_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("range",
+                  ((match match range_jsonschema int_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:448"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                ((range_to_json
+                                    (fun ppx_x ->
+                                       Ppx_deriving_jsonschema_runtime.declassify
+                                         (`Int ppx_x)))
+                                   { from = 0; to_ = 100 })))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("empty_list",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("int_list",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item -> `Int ppx_item) [1; 2; 3])))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("record",
+                 ((match match record_for_default_jsonschema with
+                         | `Assoc pairs when
+                             Stdlib.List.mem_assoc "$defs" pairs ->
+                             `Assoc
+                               (("$id",
+                                  (`String "file://shared/cases.ml:445"))
+                               ::
+                               (Stdlib.List.filter
+                                  (fun (k, _) ->
+                                     not (Stdlib.String.equal k "$id")) pairs))
+                         | other -> other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (record_for_default_to_json { score = None })))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("variant",
+                 ((match match variant_for_default_jsonschema with
+                         | `Assoc pairs when
+                             Stdlib.List.mem_assoc "$defs" pairs ->
+                             `Assoc
+                               (("$id",
+                                  (`String "file://shared/cases.ml:444"))
+                               ::
+                               (Stdlib.List.filter
+                                  (fun (k, _) ->
+                                     not (Stdlib.String.equal k "$id")) pairs))
+                         | other -> other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (variant_for_default_to_json A)))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("pairs",
+                 ((match list_jsonschema
+                           (`Assoc
+                              [("type", (`String "array"));
+                              ("prefixItems",
+                                (`List
+                                   [string_jsonschema;
+                                   option_jsonschema string_jsonschema]));
+                              ("unevaluatedItems", (`Bool false));
+                              ("minItems", (`Int 2));
+                              ("maxItems", (`Int 2))])
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item ->
+                                     match ppx_item with
+                                     | (ppx_tuple_0, ppx_tuple_1) ->
+                                         `List
+                                           [`String ppx_tuple_0;
+                                           (match ppx_tuple_1 with
+                                            | None -> `Null
+                                            | Some ppx_opt_v ->
+                                                `String ppx_opt_v)])
+                                  [("a", None); ("b", (Some "b"))])))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("pair",
+                 (`Assoc
+                    [("default",
+                       ((match (1, "hello") with
+                         | (ppx_tuple_0, ppx_tuple_1) ->
+                             `List [`Int ppx_tuple_0; `String ppx_tuple_1])));
+                    ("type", (`String "array"));
+                    ("prefixItems",
+                      (`List [int_jsonschema; string_jsonschema]));
+                    ("unevaluatedItems", (`Bool false));
+                    ("minItems", (`Int 2));
+                    ("maxItems", (`Int 2))]));
+               ("is_active",
+                 ((match bool_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`Bool false)) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("speed",
+                 ((match float_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`Float 100.0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("label",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`String "default")) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("score",
+                 ((match option_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`Int 0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+module Status =
+  struct
+    type t =
+      | Active 
+      | Inactive [@@deriving (to_json, jsonschema)]
+    include
+      struct
+        [@@@ocaml.warning "-39-11-27"]
+        let rec to_json =
+          (fun x ->
+             match x with
+             | Active -> `List [`String "Active"]
+             | Inactive -> `List [`String "Inactive"] : t -> Yojson.Basic.t)
+        let t_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Active"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "Inactive"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end
+type default_with_module_type =
+  {
+  status: Status.t [@jsonschema.default Status.Active]}[@@deriving
+                                                         jsonschema]
+include
+  struct
+    let default_with_module_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("status",
+                  ((match match Status.t_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:458"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (Status.to_json Status.Active)))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type inner_with_option_field = {
+  foo: int option [@option ][@drop_default ]}[@@deriving
+                                               (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec inner_with_option_field_to_json =
+      (fun x ->
+         match x with
+         | { foo = x_foo } ->
+             `Assoc
+               (let bnds__003_ = [] in
+                let bnds__003_ =
+                  match x_foo with
+                  | Stdlib.Option.None -> bnds__003_
+                  | Stdlib.Option.Some _ ->
+                      ("foo", ((option_to_json int_to_json) x_foo)) ::
+                      bnds__003_ in
+                bnds__003_) : inner_with_option_field -> Yojson.Basic.t)
+    let inner_with_option_field_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("foo", (option_jsonschema int_jsonschema))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+let empty_inner_with_option_field : inner_with_option_field = { foo = None }
+type outer_default_record_with_option =
+  {
+  inner: inner_with_option_field [@default empty_inner_with_option_field]}
+[@@deriving jsonschema]
+include
+  struct
+    let outer_default_record_with_option_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("inner",
+                  ((match match inner_with_option_field_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:467"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (inner_with_option_field_to_json
+                                   empty_inner_with_option_field)))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type compact_variants =
+  | A 
+  | B 
+  | C of int [@@deriving jsonschema][@@jsonschema.compact_variants ]
+include
+  struct
+    let compact_variants_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "C"))]; int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type compact_poly_variants = [ `Aaa  | `Bbb  | `Ccc of int ][@@deriving
+                                                              jsonschema]
+[@@jsonschema.compact_variants ]
+include
+  struct
+    let compact_poly_variants_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Ccc"))]; int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+module Generated_code_must_qualify_stdlib =
+  struct
+    module List = struct  end
+    module String = struct  end
+    module Array = struct  end
+    type plain_variant_with_shadowed_stdlib =
+      | A 
+      | B [@name "b"][@@deriving jsonschema]
+    include
+      struct
+        let plain_variant_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "b"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a wrapper_with_shadowed_stdlib =
+      | Wrap of 'a 
+      | Nested of 'a wrapper_with_shadowed_stdlib [@@deriving jsonschema]
+    include
+      struct
+        let wrapper_with_shadowed_stdlib_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_wrapper_with_shadowed_stdlib =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Wrap"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Nested"))];
+                           `Assoc
+                             [("$ref",
+                                (`String
+                                   "#/$defs/wrapper_with_shadowed_stdlib"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("wrapper_with_shadowed_stdlib",
+                      ppx_body_wrapper_with_shadowed_stdlib)]
+                     @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/wrapper_with_shadowed_stdlib"))]
+          [@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type rec_using_wrapper_with_shadowed_stdlib =
+      | Leaf of int 
+      | Node of rec_using_wrapper_with_shadowed_stdlib
+      wrapper_with_shadowed_stdlib [@@deriving jsonschema]
+    include
+      struct
+        let rec_using_wrapper_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_rec_using_wrapper_with_shadowed_stdlib =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "Leaf"))];
+                            int_jsonschema]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           (match wrapper_with_shadowed_stdlib_jsonschema
+                                    (`Assoc
+                                       [("$ref",
+                                          (`String
+                                             "#/$defs/rec_using_wrapper_with_shadowed_stdlib"))])
+                            with
+                            | `Assoc ppx_pairs ->
+                                (match Stdlib.List.assoc_opt "$defs"
+                                         ppx_pairs
+                                 with
+                                 | Some (`Assoc ppx_defs) ->
+                                     (ppx_eds :=
+                                        ((!ppx_eds) @
+                                           (Stdlib.List.filter
+                                              (fun (n, _) ->
+                                                 not
+                                                   (Stdlib.List.mem_assoc n
+                                                      (!ppx_eds))) ppx_defs));
+                                      `Assoc
+                                        (Stdlib.List.filter
+                                           (fun (k, _) ->
+                                              not
+                                                (Stdlib.String.equal k
+                                                   "$defs")) ppx_pairs))
+                                 | _ -> `Assoc ppx_pairs)
+                            | ppx_other -> ppx_other)]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("rec_using_wrapper_with_shadowed_stdlib",
+                      ppx_body_rec_using_wrapper_with_shadowed_stdlib)]
+                     @ (!ppx_eds))));
+            ("$ref",
+              (`String "#/$defs/rec_using_wrapper_with_shadowed_stdlib"))]
+          [@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type record_with_default_with_shadowed_stdlib =
+      {
+      items: int list [@default [1; 2]];
+      items_a: int array [@default [|1;2|]];
+      name: string [@default "x"]}[@@deriving jsonschema]
+    include
+      struct
+        let record_with_default_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("type", (`String "object"));
+              ("properties",
+                (`Assoc
+                   [("name",
+                      ((match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("default", (`String "x")) :: ppx_fields)
+                        | ppx_other -> ppx_other)));
+                   ("items_a",
+                     ((match array_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (`List
+                                   (Stdlib.Array.to_list
+                                      (Stdlib.Array.map
+                                         (fun ppx_item -> `Int ppx_item)
+                                         [|1;2|]))))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)));
+                   ("items",
+                     ((match list_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (`List
+                                   (Stdlib.List.map
+                                      (fun ppx_item -> `Int ppx_item) 
+                                      [1; 2])))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)))]));
+              ("required", (`List []));
+              ("additionalProperties", (`Bool false))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type non_rec_using_wrapper_with_shadowed_stdlib =
+      int wrapper_with_shadowed_stdlib[@@deriving jsonschema]
+    include
+      struct
+        let non_rec_using_wrapper_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
+            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                `Assoc (("$id", (`String "file://shared/cases.ml:514")) ::
+                  (Stdlib.List.filter
+                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+            | other -> other in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end
+module Nonrec_type_alias =
+  struct
+    type foo =
+      | A 
+      | B [@@deriving jsonschema]
+    include
+      struct
+        let foo_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "B"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    module X =
+      struct
+        type nonrec foo = foo[@@deriving jsonschema]
+        include
+          struct
+            let foo_jsonschema =
+              let ppx_eds = ref [] in
+              let ppx_result =
+                match foo_jsonschema with
+                | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                    `Assoc (("$id", (`String "file://shared/cases.ml:524"))
+                      ::
+                      (Stdlib.List.filter
+                         (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                         pairs))
+                | other -> other in
+              match !ppx_eds with
+              | [] -> ppx_result
+              | ppx_defs ->
+                  (match ppx_result with
+                   | `Assoc ppx_pairs ->
+                       `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) ->
+                               not (Stdlib.String.equal k "$defs")) ppx_pairs))
+                   | other -> other)[@@warning "-32-39"]
+          end[@@ocaml.doc "@inline"][@@merlin.hide ]
+      end
+  end
+module Recursive_shapes =
+  struct
+    type a =
+      | A of b 
+    and b = int[@@deriving jsonschema]
+    include
+      struct
+        let a_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/a"))][@@warning "-32-39"]
+        let b_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/b"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type t =
+      | N 
+      | S of t [@@deriving jsonschema]
+    include
+      struct
+        let t_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_t =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "N"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "S"))];
+                           `Assoc [("$ref", (`String "#/$defs/t"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("t", ppx_body_t)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/t"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a lst =
+      | Nil 
+      | Cons of 'a * 'a lst [@@deriving jsonschema]
+    include
+      struct
+        let lst_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_lst =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Nil"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Cons"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/lst"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("lst", ppx_body_lst)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/lst"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a tree =
+      | Leaf of 'a 
+      | Node of 'a * 'a forest 
+    and 'a forest =
+      | Empty 
+      | Base of 'a tree * 'a forest [@@deriving jsonschema]
+    include
+      struct
+        let tree_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
+        let forest_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/forest"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end

--- a/ppx/jsonschema/test/test.melange.expected.ml
+++ b/ppx/jsonschema/test/test.melange.expected.ml
@@ -1,0 +1,5044 @@
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
+open Melange_json.Primitives
+let string_jsonschema = `Assoc [("type", (`String "string"))]
+let int_jsonschema = `Assoc [("type", (`String "integer"))]
+let bool_jsonschema = `Assoc [("type", (`String "boolean"))]
+module Mod1 =
+  struct
+    type m_1 =
+      | A 
+      | B [@@deriving jsonschema]
+    include
+      struct
+        let m_1_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "B"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    module Mod2 =
+      struct
+        type m_2 =
+          | C 
+          | D [@@deriving jsonschema]
+        include
+          struct
+            let m_2_jsonschema =
+              let ppx_eds = ref [] in
+              let ppx_result =
+                `Assoc
+                  [("anyOf",
+                     (`List
+                        [`Assoc
+                           [("type", (`String "array"));
+                           ("prefixItems",
+                             (`List [`Assoc [("const", (`String "C"))]]));
+                           ("unevaluatedItems", (`Bool false));
+                           ("minItems", (`Int 1));
+                           ("maxItems", (`Int 1))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List [`Assoc [("const", (`String "D"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 1));
+                          ("maxItems", (`Int 1))]]))] in
+              match !ppx_eds with
+              | [] -> ppx_result
+              | ppx_defs ->
+                  (match ppx_result with
+                   | `Assoc ppx_pairs ->
+                       `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) ->
+                               not (Stdlib.String.equal k "$defs")) ppx_pairs))
+                   | other -> other)[@@warning "-32-39"]
+          end[@@ocaml.doc "@inline"][@@merlin.hide ]
+      end
+  end
+type with_modules = {
+  m: Mod1.m_1 ;
+  m2: Mod1.Mod2.m_2 }[@@deriving jsonschema]
+include
+  struct
+    let with_modules_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("m2",
+                  ((match Mod1.Mod2.m_2_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:21")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)));
+               ("m",
+                 ((match Mod1.m_1_jsonschema with
+                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://shared/cases.ml:20"))
+                         ::
+                         (Stdlib.List.filter
+                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                            pairs))
+                   | other -> other)))]));
+          ("required", (`List [`String "m2"; `String "m"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type kind =
+  | Success 
+  | Error 
+  | Skipped [@name "skipped"][@@deriving jsonschema]
+include
+  struct
+    let kind_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Success"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Error"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "skipped"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type kind_as_string =
+  | Success 
+  | Error 
+  | Skipped [@name "skipped"][@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let kind_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Success"))];
+                `Assoc [("const", (`String "Error"))];
+                `Assoc [("const", (`String "skipped"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving jsonschema]
+include
+  struct
+    let poly_kind_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Aaa"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Bbb"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "ccc"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind_as_string = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving
+                                                                  jsonschema
+                                                                    ~variant_as_string]
+include
+  struct
+    let poly_kind_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc [("const", (`String "ccc"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind_with_payload =
+  [ `Aaa of int  | `Bbb  | `Ccc of (string * bool) [@name "ccc"]][@@deriving
+                                                                   jsonschema]
+include
+  struct
+    let poly_kind_with_payload_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Aaa"))]; int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Bbb"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "ccc"))];
+                       string_jsonschema;
+                       bool_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_kind_with_payload_as_string =
+  [ `Aaa of int  | `Bbb  | `Ccc of (string * bool) [@name "ccc"]][@@deriving
+                                                                   jsonschema
+                                                                    ~variant_as_string]
+include
+  struct
+    let poly_kind_with_payload_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc [("const", (`String "ccc"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_inherit = [ `New_one  | `Second_one of int  | poly_kind][@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let poly_inherit_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "New_one"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Second_one"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                (match poly_kind_jsonschema with
+                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://shared/cases.ml:61"))
+                       ::
+                       (Stdlib.List.filter
+                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                          pairs))
+                 | other -> other)]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type poly_inherit_as_string =
+  [ `New_one  | `Second_one of int  | poly_kind_as_string][@@deriving
+                                                            jsonschema
+                                                              ~variant_as_string]
+include
+  struct
+    let poly_inherit_as_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "New_one"))];
+                `Assoc [("const", (`String "Second_one"))];
+                (match poly_kind_as_string_jsonschema with
+                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://shared/cases.ml:67"))
+                       ::
+                       (Stdlib.List.filter
+                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                          pairs))
+                 | other -> other)]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event =
+  {
+  date: float ;
+  kind_f: kind ;
+  comment: string ;
+  opt: int option [@key "opt_int"];
+  a: float array ;
+  l: string list ;
+  t: [ `Foo  | `Bar  | `Baz ] ;
+  c: char ;
+  bunch_of_bytes: bytes ;
+  string_ref: string ref ;
+  unit: unit ;
+  native_int: nativeint }[@@deriving jsonschema]
+include
+  struct
+    let event_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("native_int", int_jsonschema);
+               ("unit", unit_jsonschema);
+               ("string_ref", string_jsonschema);
+               ("bunch_of_bytes", string_jsonschema);
+               ("c", char_jsonschema);
+               ("t",
+                 (`Assoc
+                    [("anyOf",
+                       (`List
+                          [`Assoc
+                             [("type", (`String "array"));
+                             ("prefixItems",
+                               (`List [`Assoc [("const", (`String "Foo"))]]));
+                             ("unevaluatedItems", (`Bool false));
+                             ("minItems", (`Int 1));
+                             ("maxItems", (`Int 1))];
+                          `Assoc
+                            [("type", (`String "array"));
+                            ("prefixItems",
+                              (`List [`Assoc [("const", (`String "Bar"))]]));
+                            ("unevaluatedItems", (`Bool false));
+                            ("minItems", (`Int 1));
+                            ("maxItems", (`Int 1))];
+                          `Assoc
+                            [("type", (`String "array"));
+                            ("prefixItems",
+                              (`List [`Assoc [("const", (`String "Baz"))]]));
+                            ("unevaluatedItems", (`Bool false));
+                            ("minItems", (`Int 1));
+                            ("maxItems", (`Int 1))]]))]));
+               ("l", (list_jsonschema string_jsonschema));
+               ("a", (array_jsonschema float_jsonschema));
+               ("opt_int", (option_jsonschema int_jsonschema));
+               ("comment", string_jsonschema);
+               ("kind_f",
+                 ((match kind_jsonschema with
+                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                       `Assoc (("$id", (`String "file://shared/cases.ml:72"))
+                         ::
+                         (Stdlib.List.filter
+                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                            pairs))
+                   | other -> other)));
+               ("date", float_jsonschema)]));
+          ("required",
+            (`List
+               [`String "native_int";
+               `String "unit";
+               `String "string_ref";
+               `String "bunch_of_bytes";
+               `String "c";
+               `String "t";
+               `String "l";
+               `String "a";
+               `String "opt_int";
+               `String "comment";
+               `String "kind_f";
+               `String "date"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type recursive_record = {
+  a: int ;
+  b: recursive_record list }[@@deriving jsonschema]
+include
+  struct
+    let recursive_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_recursive_record =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/recursive_record"))])));
+               ("a", int_jsonschema)]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("recursive_record", ppx_body_recursive_record)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/recursive_record"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type recursive_variant =
+  | A of recursive_variant 
+  | B [@@deriving jsonschema]
+include
+  struct
+    let recursive_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_recursive_variant =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("$ref", (`String "#/$defs/recursive_variant"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("recursive_variant", ppx_body_recursive_variant)] @
+                 (!ppx_eds))));
+        ("$ref", (`String "#/$defs/recursive_variant"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tree =
+  | Leaf 
+  | Node of {
+  value: int ;
+  left: tree ;
+  right: tree } [@@deriving jsonschema]
+include
+  struct
+    let tree_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_tree =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Leaf"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Node"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("right",
+                                 (`Assoc [("$ref", (`String "#/$defs/tree"))]));
+                              ("left",
+                                (`Assoc [("$ref", (`String "#/$defs/tree"))]));
+                              ("value", int_jsonschema)]));
+                         ("required",
+                           (`List
+                              [`String "right";
+                              `String "left";
+                              `String "value"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs", (`Assoc ([("tree", ppx_body_tree)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type non_recursive = {
+  x: int ;
+  y: string }[@@deriving jsonschema]
+include
+  struct
+    let non_recursive_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("y", string_jsonschema); ("x", int_jsonschema)]));
+          ("required", (`List [`String "y"; `String "x"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type foo = {
+  bar: bar option }
+and bar = {
+  foo: foo option }[@@deriving jsonschema]
+include
+  struct
+    let foo_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_foo =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("bar",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
+          ("required", (`List [`String "bar"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_bar =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("foo",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
+          ("required", (`List [`String "foo"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("foo", ppx_body_foo); ("bar", ppx_body_bar)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/foo"))][@@warning "-32-39"]
+    let bar_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_foo =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("bar",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/bar"))])))]));
+          ("required", (`List [`String "bar"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_bar =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("foo",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/foo"))])))]));
+          ("required", (`List [`String "foo"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("foo", ppx_body_foo); ("bar", ppx_body_bar)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/bar"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type expr =
+  | Literal of int 
+  | Binary of expr * expr 
+  | Block of stmt list 
+and stmt =
+  | ExprStmt of expr 
+  | IfStmt of {
+  cond: expr ;
+  then_: stmt ;
+  else_: stmt option } [@@deriving jsonschema]
+include
+  struct
+    let expr_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_expr =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Literal"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Binary"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Block"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      let ppx_body_stmt =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ExprStmt"))];
+                        `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "IfStmt"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("else_",
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
+                              ("then_",
+                                (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
+                              ("cond",
+                                (`Assoc [("$ref", (`String "#/$defs/expr"))]))]));
+                         ("required",
+                           (`List
+                              [`String "else_";
+                              `String "then_";
+                              `String "cond"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("expr", ppx_body_expr); ("stmt", ppx_body_stmt)] @
+                 (!ppx_eds))));
+        ("$ref", (`String "#/$defs/expr"))][@@warning "-32-39"]
+    let stmt_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_expr =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Literal"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Binary"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))];
+                       `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Block"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/stmt"))])]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      let ppx_body_stmt =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ExprStmt"))];
+                        `Assoc [("$ref", (`String "#/$defs/expr"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "IfStmt"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties",
+                           (`Assoc
+                              [("else_",
+                                 (option_jsonschema
+                                    (`Assoc
+                                       [("$ref", (`String "#/$defs/stmt"))])));
+                              ("then_",
+                                (`Assoc [("$ref", (`String "#/$defs/stmt"))]));
+                              ("cond",
+                                (`Assoc [("$ref", (`String "#/$defs/expr"))]))]));
+                         ("required",
+                           (`List
+                              [`String "else_";
+                              `String "then_";
+                              `String "cond"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("expr", ppx_body_expr); ("stmt", ppx_body_stmt)] @
+                 (!ppx_eds))));
+        ("$ref", (`String "#/$defs/stmt"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type alpha = {
+  x: int }
+and beta = {
+  y: string }[@@deriving jsonschema]
+include
+  struct
+    let alpha_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+    let beta_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("y", string_jsonschema)]));
+          ("required", (`List [`String "y"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type node_a = {
+  b: node_b option ;
+  c: node_c option }
+and node_b = {
+  a: node_a option ;
+  c: node_c option }
+and node_c = {
+  a: node_a option ;
+  b: node_b option }[@@deriving jsonschema]
+include
+  struct
+    let node_a_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_node_a =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("b",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_b =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_c =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/node_a"))][@@warning "-32-39"]
+    let node_b_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_node_a =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("b",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_b =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_c =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/node_b"))][@@warning "-32-39"]
+    let node_c_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_node_a =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("b",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_b"))])))]));
+          ("required", (`List [`String "c"; `String "b"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_b =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("c",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_c"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "c"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      let ppx_body_node_c =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  (option_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/node_b"))])));
+               ("a",
+                 (option_jsonschema
+                    (`Assoc [("$ref", (`String "#/$defs/node_a"))])))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("node_a", ppx_body_node_a);
+               ("node_b", ppx_body_node_b);
+               ("node_c", ppx_body_node_c)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/node_c"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type recursive_tuple =
+  | Leaf of int 
+  | Branch of (recursive_tuple * recursive_tuple) [@@deriving jsonschema]
+include
+  struct
+    let recursive_tuple_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_recursive_tuple =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Leaf"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Branch"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc
+                                 [("$ref",
+                                    (`String "#/$defs/recursive_tuple"))];
+                              `Assoc
+                                [("$ref",
+                                   (`String "#/$defs/recursive_tuple"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 2));
+                         ("maxItems", (`Int 2))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc
+              ([("recursive_tuple", ppx_body_recursive_tuple)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/recursive_tuple"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type int_tree = tree[@@deriving jsonschema]
+include
+  struct
+    let int_tree_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match tree_jsonschema with
+        | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://shared/cases.ml:140")) ::
+              (Stdlib.List.filter
+                 (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type events = event list[@@deriving jsonschema]
+include
+  struct
+    let events_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (match event_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:141")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type eventss = event list list[@@deriving jsonschema]
+include
+  struct
+    let eventss_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (list_jsonschema
+             (match event_jsonschema with
+              | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                  `Assoc (("$id", (`String "file://shared/cases.ml:142")) ::
+                    (Stdlib.List.filter
+                       (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                       pairs))
+              | other -> other)) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event_comment = (event * string)[@@deriving jsonschema]
+include
+  struct
+    let event_comment_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems",
+            (`List
+               [(match event_jsonschema with
+                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                     `Assoc (("$id", (`String "file://shared/cases.ml:143"))
+                       ::
+                       (Stdlib.List.filter
+                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                          pairs))
+                 | other -> other);
+               string_jsonschema]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event_comments' = event_comment list[@@deriving jsonschema]
+include
+  struct
+    let event_comments'_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (match event_comment_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:144")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type event_n = (event * int) list[@@deriving jsonschema]
+include
+  struct
+    let event_n_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        list_jsonschema
+          (`Assoc
+             [("type", (`String "array"));
+             ("prefixItems",
+               (`List
+                  [(match event_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:145")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other);
+                  int_jsonschema]));
+             ("unevaluatedItems", (`Bool false));
+             ("minItems", (`Int 2));
+             ("maxItems", (`Int 2))]) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type events_array = events array[@@deriving jsonschema]
+include
+  struct
+    let events_array_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        array_jsonschema
+          (match events_jsonschema with
+           | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+               `Assoc (("$id", (`String "file://shared/cases.ml:146")) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+           | other -> other) in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type numbers = int list[@@deriving jsonschema]
+include
+  struct
+    let numbers_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result = list_jsonschema int_jsonschema in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type opt = int option[@@deriving jsonschema]
+include
+  struct
+    let opt_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result = option_jsonschema int_jsonschema in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type using_m = {
+  m: Mod1.m_1 }[@@deriving jsonschema]
+include
+  struct
+    let using_m_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("m",
+                  ((match Mod1.m_1_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:149")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "m"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'param2 poly2 =
+  | C of 'param2 [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let poly2_jsonschema _param2 =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc [("anyOf", (`List [`Assoc [("const", (`String "C"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tuple_with_variant = (int * [ `A  | `B [@name "second_cstr"]])[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let tuple_with_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems",
+            (`List
+               [int_jsonschema;
+               `Assoc
+                 [("anyOf",
+                    (`List
+                       [`Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List [`Assoc [("const", (`String "A"))]]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 1));
+                          ("maxItems", (`Int 1))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc [("const", (`String "second_cstr"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 1));
+                         ("maxItems", (`Int 1))]]))]]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type player_scores =
+  {
+  player: string ;
+  scores: numbers [@ref "numbers"][@key "scores_ref"]}[@@deriving jsonschema]
+include
+  struct
+    let player_scores_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("scores_ref",
+                  (`Assoc [("$ref", (`String "#/$defs/numbers"))]));
+               ("player", string_jsonschema)]));
+          ("required", (`List [`String "scores_ref"; `String "player"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type address = {
+  street: string ;
+  city: string ;
+  zip: string }[@@deriving jsonschema]
+include
+  struct
+    let address_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("zip", string_jsonschema);
+               ("city", string_jsonschema);
+               ("street", string_jsonschema)]));
+          ("required",
+            (`List [`String "zip"; `String "city"; `String "street"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t = {
+  name: string ;
+  age: int ;
+  email: string option ;
+  address: address }[@@deriving jsonschema]
+include
+  struct
+    let t_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("address",
+                  ((match address_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:167")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
+          ("required",
+            (`List
+               [`String "address";
+               `String "email";
+               `String "age";
+               `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tt =
+  {
+  name: string ;
+  age: int ;
+  email: string option ;
+  home_address: address [@ref "shared_address"];
+  work_address: address [@ref "shared_address"];
+  retreat_address: address [@ref "shared_address"]}[@@deriving jsonschema]
+include
+  struct
+    let tt_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("retreat_address",
+                  (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("work_address",
+                 (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("home_address",
+                 (`Assoc [("$ref", (`String "#/$defs/shared_address"))]));
+               ("email", (option_jsonschema string_jsonschema));
+               ("age", int_jsonschema);
+               ("name", string_jsonschema)]));
+          ("required",
+            (`List
+               [`String "retreat_address";
+               `String "work_address";
+               `String "home_address";
+               `String "email";
+               `String "age";
+               `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type c = char[@@deriving jsonschema]
+include
+  struct
+    let c_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result = char_jsonschema in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type variant_inline_record =
+  | A of {
+  a: int } 
+  | B of {
+  b: string } [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let variant_inline_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type inline_record_with_extra_fields =
+  | User of {
+  name: string ;
+  email: string } [@jsonschema.allow_extra_fields ]
+  | Guest of {
+  ip: string } [@@deriving jsonschema]
+include
+  struct
+    let inline_record_with_extra_fields_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "User"))];
+                        `Assoc
+                          [("type", (`String "object"));
+                          ("properties",
+                            (`Assoc
+                               [("email", string_jsonschema);
+                               ("name", string_jsonschema)]));
+                          ("required",
+                            (`List [`String "email"; `String "name"]));
+                          ("additionalProperties", (`Bool true))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Guest"))];
+                       `Assoc
+                         [("type", (`String "object"));
+                         ("properties", (`Assoc [("ip", string_jsonschema)]));
+                         ("required", (`List [`String "ip"]));
+                         ("additionalProperties", (`Bool false))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type variant_with_payload =
+  | A of int 
+  | B 
+  | C of int * string 
+  | D of (int * string * bool) [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let variant_with_payload_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))];
+                `Assoc [("const", (`String "C"))];
+                `Assoc [("const", (`String "D"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t1 =
+  | Typ 
+  | Class of string [@@deriving jsonschema]
+include
+  struct
+    let t1_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Typ"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Class"))];
+                       string_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t2 =
+  | Typ 
+  | Class of string [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let t2_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Typ"))];
+                `Assoc [("const", (`String "Class"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t3 =
+  | Typ [@name "type"]
+  | Class of string [@name "class"][@@deriving jsonschema]
+include
+  struct
+    let t3_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "type"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "class"))];
+                       string_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t4 = (int * string)[@@deriving jsonschema]
+include
+  struct
+    let t4_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "array"));
+          ("prefixItems", (`List [int_jsonschema; string_jsonschema]));
+          ("unevaluatedItems", (`Bool false));
+          ("minItems", (`Int 2));
+          ("maxItems", (`Int 2))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t5 = [ `A of (int * string * bool) ][@@deriving jsonschema]
+include
+  struct
+    let t5_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t6 = [ `A of ((int * string * bool) * float) ][@@deriving jsonschema]
+include
+  struct
+    let t6_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))];
+                        float_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 3));
+                   ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t7 =
+  | A of int * string * bool [@@deriving jsonschema]
+include
+  struct
+    let t7_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t8 =
+  | A of (int * string * bool) [@@deriving jsonschema]
+include
+  struct
+    let t8_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t9 =
+  | A of (int * string * bool) * float [@@deriving jsonschema]
+include
+  struct
+    let t9_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))];
+                        float_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 3));
+                   ("maxItems", (`Int 3))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t10 = [ `A of (int * string * bool) ][@@deriving jsonschema]
+include
+  struct
+    let t10_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        int_jsonschema;
+                        string_jsonschema;
+                        bool_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 4));
+                   ("maxItems", (`Int 4))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t11 = [ `B of (int * string * bool) ][@@deriving
+                                            jsonschema
+                                              ~polymorphic_variant_tuple]
+include
+  struct
+    let t11_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "B"))];
+                        `Assoc
+                          [("type", (`String "array"));
+                          ("prefixItems",
+                            (`List
+                               [int_jsonschema;
+                               string_jsonschema;
+                               bool_jsonschema]));
+                          ("unevaluatedItems", (`Bool false));
+                          ("minItems", (`Int 3));
+                          ("maxItems", (`Int 3))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type obj2 = {
+  x: int }[@@deriving jsonschema][@@jsonschema.allow_extra_fields ]
+include
+  struct
+    let obj2_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type obj1 = {
+  obj2: obj2 }[@@deriving jsonschema]
+include
+  struct
+    let obj1_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("obj2",
+                  ((match obj2_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:218")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "obj2"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_obj = {
+  obj1: obj1 }[@@deriving jsonschema][@@allow_extra_fields ]
+include
+  struct
+    let nested_obj_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("obj1",
+                  ((match obj1_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:219")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)))]));
+          ("required", (`List [`String "obj1"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type x_without_extra = {
+  x: int }[@@deriving jsonschema][@@allow_extra_fields ]
+include
+  struct
+    let x_without_extra_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("x", int_jsonschema)]));
+          ("required", (`List [`String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type x_with_extra = {
+  x: int ;
+  y: int }[@@deriving jsonschema][@@allow_extra_fields ]
+include
+  struct
+    let x_with_extra_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("y", int_jsonschema); ("x", int_jsonschema)]));
+          ("required", (`List [`String "y"; `String "x"]));
+          ("additionalProperties", (`Bool true))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'url generic_link_traffic = {
+  title: string option ;
+  url: 'url }[@@deriving jsonschema]
+include
+  struct
+    let generic_link_traffic_jsonschema url =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("url", url);
+               ("title", (option_jsonschema string_jsonschema))]));
+          ("required", (`List [`String "url"; `String "title"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type string_link_traffic = string generic_link_traffic[@@deriving jsonschema]
+include
+  struct
+    let string_link_traffic_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match generic_link_traffic_jsonschema string_jsonschema with
+        | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://shared/cases.ml:231")) ::
+              (Stdlib.List.filter
+                 (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a poly_variant =
+  | A 
+  | B of 'a [@@deriving jsonschema]
+include
+  struct
+    let poly_variant_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]; a]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) multi_param = {
+  first: 'a ;
+  second: 'b ;
+  label: string }[@@deriving jsonschema]
+include
+  struct
+    let multi_param_jsonschema a b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("label", string_jsonschema); ("second", b); ("first", a)]));
+          ("required",
+            (`List [`String "label"; `String "second"; `String "first"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a param_list = 'a list[@@deriving jsonschema]
+include
+  struct
+    let param_list_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result = list_jsonschema a in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) either =
+  | Left of 'a 
+  | Right of 'b [@@deriving jsonschema]
+include
+  struct
+    let either_jsonschema a b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Left"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Right"))]; b]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) either_alias = ('a, 'b) either[@@deriving jsonschema]
+include
+  struct
+    let either_alias_jsonschema a b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match either_jsonschema a b with
+        | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+            `Assoc (("$id", (`String "file://shared/cases.ml:247")) ::
+              (Stdlib.List.filter
+                 (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+        | other -> other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('a, 'b) direction =
+  | North 
+  | South [@@deriving jsonschema ~variant_as_string]
+include
+  struct
+    let direction_jsonschema _a _b =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "North"))];
+                `Assoc [("const", (`String "South"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type tool_params =
+  {
+  query: string [@jsonschema.description "The search query to execute"];
+  max_results: int
+    [@jsonschema.description "Maximum number of results to return"]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let tool_params_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("max_results",
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String "Maximum number of results to return"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("query",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description",
+                            (`String "The search query to execute"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "max_results"; `String "query"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_record =
+  {
+  name: string [@jsonschema.description "The user's full name"];
+  age: int option
+    [@jsonschema.option ][@jsonschema.description "The user's age"]}[@@deriving
+                                                                    jsonschema]
+[@@jsonschema.description "A user object"]
+include
+  struct
+    let described_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A user object"));
+          ("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("age",
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("name",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_key_and_desc =
+  {
+  opt: int option
+    [@key "opt_int"][@jsonschema.option ][@jsonschema.description
+                                           "An optional integer"]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let with_key_and_desc_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("opt_int",
+                  ((match option_jsonschema int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description", (`String "An optional integer"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_variant =
+  | Plain [@jsonschema.description "No payload"]
+  | With_int of int [@jsonschema.description "Single integer tag"]
+  | Pair of string * int [@jsonschema.description "String and int"]
+  | Description_value of ((string)[@jsonschema.description "A string value"]) 
+[@@deriving jsonschema]
+include
+  struct
+    let described_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                `Assoc
+                  [("description", (`String "String and int"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Pair"))];
+                       string_jsonschema;
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Description_value"))];
+                       (match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc
+                              (("description", (`String "A string value")) ::
+                              ppx_fields)
+                        | ppx_other -> ppx_other)]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_variant_inline_record =
+  | Point of {
+  x: int ;
+  y: int } [@jsonschema.description "A 2D point"][@@deriving jsonschema]
+include
+  struct
+    let described_variant_inline_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "A 2D point"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Point"))];
+                        `Assoc
+                          [("type", (`String "object"));
+                          ("properties",
+                            (`Assoc
+                               [("y", int_jsonschema); ("x", int_jsonschema)]));
+                          ("required", (`List [`String "y"; `String "x"]));
+                          ("additionalProperties", (`Bool false))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type described_variant_string =
+  | A [@jsonschema.description "First choice"]
+  | B [@jsonschema.description "Second choice"][@@deriving
+                                                 jsonschema
+                                                   ~variant_as_string]
+include
+  struct
+    let described_variant_string_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "First choice"));
+                   ("const", (`String "A"))];
+                `Assoc
+                  [("description", (`String "Second choice"));
+                  ("const", (`String "B"))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_record =
+  {
+  name: string [@ocaml.doc " The user's full name "];
+  age: int [@ocaml.doc " The user's age "]}[@@ocaml.doc " A user object "]
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description", (`String "A user object"));
+          ("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("age",
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "The user's age"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("name",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("description", (`String "The user's full name"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "age"; `String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_disabled =
+  {
+  name: string [@ocaml.doc " The user's full name "]}[@@ocaml.doc
+                                                       " A user object "]
+[@@deriving jsonschema]
+include
+  struct
+    let doc_comment_disabled_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("name", string_jsonschema)]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_override =
+  {
+  field: string
+    [@jsonschema.description "explicit wins"][@ocaml.doc " ocaml.doc loses "]}
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_override_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("field",
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "explicit wins")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "field"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_variant =
+  | Plain [@ocaml.doc " No payload "]
+  | With_int of int [@ocaml.doc " Single integer tag "][@@deriving
+                                                         jsonschema
+                                                           ~ocaml_doc]
+include
+  struct
+    let doc_comment_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_core_type = ((string)[@ocaml.doc " A string alias "])
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_core_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A string alias")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_attribute_alias = ((string)[@doc " Alias fallback "])[@@deriving
+                                                                jsonschema
+                                                                  ~ocaml_doc]
+include
+  struct
+    let doc_attribute_alias_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "Alias fallback")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[@@@ocamlformat "disable"]
+type doc_comment_multiline =
+  {
+  name: string
+    [@ocaml.doc
+      " The user's full name.\n          Must be non-empty and under 100 characters. "]}
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_multiline_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("name",
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("description",
+                             (`String
+                                "The user's full name.\n          Must be non-empty and under 100 characters."))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "name"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+[@@@ocamlformat "enable"]
+type doc_comment_poly_variant =
+  [ `Plain [@ocaml.doc " No payload "]
+  | `With_int of int [@ocaml.doc " Single integer tag "]][@@deriving
+                                                           jsonschema
+                                                             ~ocaml_doc]
+include
+  struct
+    let doc_comment_poly_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "No payload"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Plain"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("description", (`String "Single integer tag"));
+                  ("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "With_int"))];
+                       int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_multiple =
+  ((string)[@ocaml.doc " first block "][@ocaml.doc " second block "][@doc
+                                                                    " third block "])
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_multiple_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "first block\n\nsecond block\n\nthird block"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type doc_comment_poly_variant_override =
+  [
+    `Tagged
+      [@jsonschema.description "explicit wins"][@ocaml.doc
+                                                 " ocaml.doc loses "]]
+[@@deriving jsonschema ~ocaml_doc]
+include
+  struct
+    let doc_comment_poly_variant_override_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("description", (`String "explicit wins"));
+                   ("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Tagged"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type computation_result =
+  | Ok 
+  | Err of string [@@deriving jsonschema][@@jsonschema.description
+                                           "Either success or an error message string"]
+include
+  struct
+    let computation_result_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("description",
+             (`String "Either success or an error message string"));
+          ("anyOf",
+            (`List
+               [`Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "Ok"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))];
+               `Assoc
+                 [("type", (`String "array"));
+                 ("prefixItems",
+                   (`List
+                      [`Assoc [("const", (`String "Err"))];
+                      string_jsonschema]));
+                 ("unevaluatedItems", (`Bool false));
+                 ("minItems", (`Int 2));
+                 ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nullable_fields =
+  {
+  plain: string option ;
+  drop_simple: string option [@jsonschema.option ];
+  drop_complex: int list option [@jsonschema.option ]}[@@deriving jsonschema]
+include
+  struct
+    let nullable_fields_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("drop_complex",
+                  (option_jsonschema (list_jsonschema int_jsonschema)));
+               ("drop_simple", (option_jsonschema string_jsonschema));
+               ("plain", (option_jsonschema string_jsonschema))]));
+          ("required", (`List [`String "plain"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type melange_json_defaults =
+  {
+  required_value: int ;
+  option_value: string option [@option ];
+  option_default_none: string [@default None];
+  default_none: string [@default None];
+  default_value: string [@default "-"];
+  dropped_option: int option [@option ][@drop_default ];
+  dropped_default: int list [@default []][@drop_default ];
+  custom_drop_default: float [@default 0.0][@drop_default Float.equal]}
+[@@deriving jsonschema]
+include
+  struct
+    let melange_json_defaults_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("custom_drop_default",
+                  ((match float_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("default", (`Float 0.0)) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("dropped_default",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("dropped_option", (option_jsonschema int_jsonschema));
+               ("default_value",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`String "-")) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("default_none",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("option_default_none",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", `Null) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("option_value", (option_jsonschema string_jsonschema));
+               ("required_value", int_jsonschema)]));
+          ("required", (`List [`String "required_value"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type composing_type = string
+let composing_type_jsonschema =
+  `Assoc
+    [("type", (`String "string")); ("description", (`String "A string"))]
+type composing_record =
+  {
+  composing_type: composing_type option [@jsonschema.option ]}[@@deriving
+                                                                jsonschema]
+include
+  struct
+    let composing_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("composing_type",
+                  (option_jsonschema
+                     (match composing_type_jsonschema with
+                      | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                          ->
+                          `Assoc
+                            (("$id", (`String "file://shared/cases.ml:361"))
+                            ::
+                            (Stdlib.List.filter
+                               (fun (k, _) ->
+                                  not (Stdlib.String.equal k "$id")) pairs))
+                      | other -> other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_format = string[@@jsonschema.format "date-time"][@@deriving
+                                                            jsonschema]
+include
+  struct
+    let with_format_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match string_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("format", (`String "date-time")) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_format_record =
+  {
+  with_format: string [@jsonschema.format "date-time"]}[@@deriving
+                                                         jsonschema]
+include
+  struct
+    let with_format_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("with_format",
+                  ((match string_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("format", (`String "date-time")) ::
+                          ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "with_format"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_format_variant =
+  | A of
+  ((string)[@jsonschema.format "date-time"][@jsonschema.description
+                                             "A date-time string"])
+  
+  | B [@@deriving jsonschema]
+include
+  struct
+    let with_format_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "A"))];
+                        (match match string_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc
+                                     (("description",
+                                        (`String "A date-time string"))
+                                     :: ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("format", (`String "date-time")) ::
+                               ppx_fields)
+                         | ppx_other -> ppx_other)]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a grade' =
+  | A of 'a 
+  | B of ('a grade' * 'a grade') 
+  | C 
+type 'a grade = 'a grade' =
+  | A of 'a 
+  | B of ('a grade * 'a grade) 
+  | C [@@deriving jsonschema]
+include
+  struct
+    let grade_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_body_grade =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "B"))];
+                       `Assoc
+                         [("type", (`String "array"));
+                         ("prefixItems",
+                           (`List
+                              [`Assoc [("$ref", (`String "#/$defs/grade"))];
+                              `Assoc [("$ref", (`String "#/$defs/grade"))]]));
+                         ("unevaluatedItems", (`Bool false));
+                         ("minItems", (`Int 2));
+                         ("maxItems", (`Int 2))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "C"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      `Assoc
+        [("$defs", (`Assoc ([("grade", ppx_body_grade)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/grade"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type self_ref = {
+  children: self_ref list }[@@deriving jsonschema]
+include
+  struct
+    let self_ref_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_self_ref =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("children",
+                  (list_jsonschema
+                     (`Assoc [("$ref", (`String "#/$defs/self_ref"))])))]));
+          ("required", (`List [`String "children"]));
+          ("additionalProperties", (`Bool false))] in
+      `Assoc
+        [("$defs", (`Assoc ([("self_ref", ppx_body_self_ref)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/self_ref"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type two_self_refs = {
+  a: self_ref ;
+  b: self_ref }[@@deriving jsonschema]
+include
+  struct
+    let two_self_refs_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("b",
+                  ((match self_ref_jsonschema with
+                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
+                        ->
+                        `Assoc
+                          (("$id", (`String "file://shared/cases.ml:380")) ::
+                          (Stdlib.List.filter
+                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                             pairs))
+                    | other -> other)));
+               ("a",
+                 ((match self_ref_jsonschema with
+                   | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                       `Assoc
+                         (("$id", (`String "file://shared/cases.ml:379")) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                            pairs))
+                   | other -> other)))]));
+          ("required", (`List [`String "b"; `String "a"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('atom, 'group_atom) filter =
+  | Atom of 'atom 
+  | Group of ('atom, 'group_atom) filter list * 'group_atom [@@deriving
+                                                              jsonschema]
+include
+  struct
+    let filter_jsonschema atom group_atom =
+      let ppx_eds = ref [] in
+      let ppx_body_filter =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "Atom"))]; atom]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Group"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/filter"))]);
+                       group_atom]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 3));
+                  ("maxItems", (`Int 3))]]))] in
+      `Assoc
+        [("$defs", (`Assoc ([("filter", ppx_body_filter)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/filter"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type ('atom, 'group_atom) bool_filter =
+  | BoolAtom of ('atom, 'group_atom) filter 
+  | BoolFilterGroup of ('atom, 'group_atom) bool_filter list [@@deriving
+                                                               jsonschema]
+include
+  struct
+    let bool_filter_jsonschema atom group_atom =
+      let ppx_eds = ref [] in
+      let ppx_body_bool_filter =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "BoolAtom"))];
+                        (match filter_jsonschema atom group_atom with
+                         | `Assoc pairs when
+                             Stdlib.List.mem_assoc "$defs" pairs ->
+                             `Assoc
+                               (("$id",
+                                  (`String "file://shared/cases.ml:388"))
+                               ::
+                               (Stdlib.List.filter
+                                  (fun (k, _) ->
+                                     not (Stdlib.String.equal k "$id")) pairs))
+                         | other -> other)]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "BoolFilterGroup"))];
+                       list_jsonschema
+                         (`Assoc [("$ref", (`String "#/$defs/bool_filter"))])]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc ([("bool_filter", ppx_body_bool_filter)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/bool_filter"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a rec_wrapper =
+  | RWrap of 'a 
+  | RNested of 'a rec_wrapper [@@deriving jsonschema]
+include
+  struct
+    let rec_wrapper_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_body_rec_wrapper =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "RWrap"))]; a]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "RNested"))];
+                       `Assoc [("$ref", (`String "#/$defs/rec_wrapper"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc ([("rec_wrapper", ppx_body_rec_wrapper)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/rec_wrapper"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type outer_rec =
+  | ORLeaf of int 
+  | ORNode of outer_rec rec_wrapper [@@deriving jsonschema]
+include
+  struct
+    let outer_rec_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_body_outer_rec =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "ORLeaf"))];
+                        int_jsonschema]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "ORNode"))];
+                       (match rec_wrapper_jsonschema
+                                (`Assoc
+                                   [("$ref", (`String "#/$defs/outer_rec"))])
+                        with
+                        | `Assoc ppx_pairs ->
+                            (match Stdlib.List.assoc_opt "$defs" ppx_pairs
+                             with
+                             | Some (`Assoc ppx_defs) ->
+                                 (ppx_eds :=
+                                    ((!ppx_eds) @
+                                       (Stdlib.List.filter
+                                          (fun (n, _) ->
+                                             not
+                                               (Stdlib.List.mem_assoc n
+                                                  (!ppx_eds))) ppx_defs));
+                                  `Assoc
+                                    (Stdlib.List.filter
+                                       (fun (k, _) ->
+                                          not (Stdlib.String.equal k "$defs"))
+                                       ppx_pairs))
+                             | _ -> `Assoc ppx_pairs)
+                        | ppx_other -> ppx_other)]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      `Assoc
+        [("$defs",
+           (`Assoc ([("outer_rec", ppx_body_outer_rec)] @ (!ppx_eds))));
+        ("$ref", (`String "#/$defs/outer_rec"))][@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_maximum = int[@@jsonschema.maximum 100][@@deriving jsonschema]
+include
+  struct
+    let with_maximum_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match int_jsonschema with
+        | `Assoc ppx_fields -> `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_maximum_record = {
+  field: int [@jsonschema.maximum 100]}[@@deriving jsonschema]
+include
+  struct
+    let with_maximum_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("field",
+                  ((match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "field"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type attrs_core_type =
+  ((int)[@jsonschema.attrs
+          {
+            maximum = 100;
+            minimum = 0;
+            description = "Integer percentage value (0-100 inclusive)"
+          }])[@@deriving jsonschema]
+include
+  struct
+    let attrs_core_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match match int_jsonschema with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                    | ppx_other -> ppx_other
+              with
+              | `Assoc ppx_fields ->
+                  `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc
+              (("description",
+                 (`String "Integer percentage value (0-100 inclusive)"))
+              :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type attrs_record =
+  {
+  score: int
+    [@jsonschema.attrs
+      { maximum = 100; minimum = 0; description = "Score out of 100" }];
+  label: string
+    [@jsonschema.attrs
+      { format = "date-time"; description = "An ISO date-time" }]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let attrs_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("label",
+                  ((match match string_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("format", (`String "date-time")) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("description", (`String "An ISO date-time"))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("score",
+                 ((match match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("description", (`String "Score out of 100"))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "label"; `String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type attrs_type_decl = int[@@jsonschema.attrs
+                            { description = "A plain integer" }][@@deriving
+                                                                  jsonschema]
+include
+  struct
+    let attrs_type_decl_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match int_jsonschema with
+        | `Assoc ppx_fields ->
+            `Assoc (("description", (`String "A plain integer")) ::
+              ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_core_type_int =
+  ((int)[@jsonschema.minimum 0][@jsonschema.maximum 100])[@@deriving
+                                                           jsonschema]
+include
+  struct
+    let minimum_core_type_int_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_core_type_float =
+  ((float)[@jsonschema.minimum 0.0][@jsonschema.maximum 1.0])[@@deriving
+                                                               jsonschema]
+include
+  struct
+    let minimum_core_type_float_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_record =
+  {
+  score: int [@jsonschema.minimum 0][@jsonschema.maximum 100];
+  ratio: float [@jsonschema.minimum 0.0][@jsonschema.maximum 1.0]}[@@deriving
+                                                                    jsonschema]
+include
+  struct
+    let minimum_maximum_record_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("ratio",
+                  ((match match float_jsonschema with
+                          | `Assoc ppx_fields ->
+                              `Assoc (("maximum", (`Float 1.0)) ::
+                                ppx_fields)
+                          | ppx_other -> ppx_other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("score",
+                 ((match match int_jsonschema with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("maximum", (`Int 100)) :: ppx_fields)
+                         | ppx_other -> ppx_other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List [`String "ratio"; `String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_type_decl_int = int[@@jsonschema.minimum 0][@@jsonschema.maximum
+                                                                  255]
+[@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_type_decl_int_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match int_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Int 255)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields -> `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_type_decl_float = float[@@jsonschema.minimum 0.0]
+[@@jsonschema.maximum 1.0][@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_type_decl_float_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        match match float_jsonschema with
+              | `Assoc ppx_fields ->
+                  `Assoc (("maximum", (`Float 1.0)) :: ppx_fields)
+              | ppx_other -> ppx_other
+        with
+        | `Assoc ppx_fields ->
+            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+        | ppx_other -> ppx_other in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type minimum_maximum_variant =
+  | Percentage of ((int)[@jsonschema.minimum 0][@jsonschema.maximum 100]) 
+  | Factor of ((float)[@jsonschema.minimum 0.0][@jsonschema.maximum 1.0]) 
+[@@deriving jsonschema]
+include
+  struct
+    let minimum_maximum_variant_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List
+                        [`Assoc [("const", (`String "Percentage"))];
+                        (match match int_jsonschema with
+                               | `Assoc ppx_fields ->
+                                   `Assoc (("maximum", (`Int 100)) ::
+                                     ppx_fields)
+                               | ppx_other -> ppx_other
+                         with
+                         | `Assoc ppx_fields ->
+                             `Assoc (("minimum", (`Int 0)) :: ppx_fields)
+                         | ppx_other -> ppx_other)]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 2));
+                   ("maxItems", (`Int 2))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Factor"))];
+                       (match match float_jsonschema with
+                              | `Assoc ppx_fields ->
+                                  `Assoc (("maximum", (`Float 1.0)) ::
+                                    ppx_fields)
+                              | ppx_other -> ppx_other
+                        with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("minimum", (`Float 0.0)) :: ppx_fields)
+                        | ppx_other -> ppx_other)]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type variant_for_default =
+  | A 
+  | B [@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec variant_for_default_to_json =
+      (fun x ->
+         match x with
+         | A -> (Obj.magic [|(Obj.magic "A" : Js.Json.t)|] : Js.Json.t)
+         | B -> (Obj.magic [|(Obj.magic "B" : Js.Json.t)|] : Js.Json.t) : 
+      variant_for_default -> Js.Json.t)
+    let variant_for_default_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc
+                   [("type", (`String "array"));
+                   ("prefixItems",
+                     (`List [`Assoc [("const", (`String "A"))]]));
+                   ("unevaluatedItems", (`Bool false));
+                   ("minItems", (`Int 1));
+                   ("maxItems", (`Int 1))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List [`Assoc [("const", (`String "B"))]]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 1));
+                  ("maxItems", (`Int 1))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type 'a range = {
+  from: 'a ;
+  to_: 'a [@key "to"]}[@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec range_to_json a_to_json =
+      (fun x ->
+         match x with
+         | { from = x_from; to_ = x_to_ } ->
+             (Obj.magic
+                (let module J =
+                   struct
+                     external unsafe_expr :
+                       from:'a0 ->
+                         \#to:'a1 -> < from: 'a0  ;\#to: 'a1   >  Js.t = ""
+                         ""[@@ocaml.warning "-unboxable-type-in-prim-decl"]
+                     [@@mel.internal.ffi
+                       "\132\149\166\190\000\000\000\018\000\000\000\t\000\000\000\023\000\000\000\022\145\160\160A\144$from\160\160A\144\"to@"]
+                   end in
+                   J.unsafe_expr ~from:(a_to_json x_from)
+                     ~\#to:(a_to_json x_to_)) : Js.Json.t) : 'a range ->
+                                                               Js.Json.t)
+    let range_jsonschema a =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties", (`Assoc [("to", a); ("from", a)]));
+          ("required", (`List [`String "to"; `String "from"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type record_for_default = {
+  score: int option }[@@deriving (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec record_for_default_to_json =
+      (fun x ->
+         match x with
+         | { score = x_score } ->
+             (Obj.magic
+                (let module J =
+                   struct
+                     external unsafe_expr :
+                       score:'a0 -> < score: 'a0   >  Js.t = "" ""[@@ocaml.warning
+                                                                    "-unboxable-type-in-prim-decl"]
+                     [@@mel.internal.ffi
+                       "\132\149\166\190\000\000\000\012\000\000\000\005\000\000\000\r\000\000\000\012\145\160\160A\144%score@"]
+                   end in
+                   J.unsafe_expr
+                     ~score:((option_to_json int_to_json) x_score)) : 
+             Js.Json.t) : record_for_default -> Js.Json.t)
+    let record_for_default_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("score", (option_jsonschema int_jsonschema))]));
+          ("required", (`List [`String "score"]));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type default_value =
+  {
+  score: int option [@default 0];
+  label: string [@jsonschema.default "default"];
+  speed: float [@jsonschema.default 100.0];
+  is_active: bool [@jsonschema.default false];
+  pair: (int * string) [@jsonschema.default (1, "hello")];
+  pairs: (string * string option) list
+    [@default [("a", None); ("b", (Some "b"))]];
+  variant: variant_for_default [@jsonschema.default A];
+  record: record_for_default [@jsonschema.default { score = None }];
+  int_list: int list [@jsonschema.default [1; 2; 3]];
+  empty_list: int list [@jsonschema.default []];
+  range: int range [@jsonschema.default { from = 0; to_ = 100 }]}[@@deriving
+                                                                   jsonschema]
+include
+  struct
+    let default_value_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("range",
+                  ((match match range_jsonschema int_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:448"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                ((range_to_json
+                                    (fun ppx_x ->
+                                       Ppx_deriving_jsonschema_runtime.declassify
+                                         (`Int ppx_x)))
+                                   { from = 0; to_ = 100 })))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)));
+               ("empty_list",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`List [])) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("int_list",
+                 ((match list_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item -> `Int ppx_item) [1; 2; 3])))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("record",
+                 ((match match record_for_default_jsonschema with
+                         | `Assoc pairs when
+                             Stdlib.List.mem_assoc "$defs" pairs ->
+                             `Assoc
+                               (("$id",
+                                  (`String "file://shared/cases.ml:445"))
+                               ::
+                               (Stdlib.List.filter
+                                  (fun (k, _) ->
+                                     not (Stdlib.String.equal k "$id")) pairs))
+                         | other -> other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (record_for_default_to_json { score = None })))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("variant",
+                 ((match match variant_for_default_jsonschema with
+                         | `Assoc pairs when
+                             Stdlib.List.mem_assoc "$defs" pairs ->
+                             `Assoc
+                               (("$id",
+                                  (`String "file://shared/cases.ml:444"))
+                               ::
+                               (Stdlib.List.filter
+                                  (fun (k, _) ->
+                                     not (Stdlib.String.equal k "$id")) pairs))
+                         | other -> other
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (Ppx_deriving_jsonschema_runtime.classify
+                               (variant_for_default_to_json A)))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("pairs",
+                 ((match list_jsonschema
+                           (`Assoc
+                              [("type", (`String "array"));
+                              ("prefixItems",
+                                (`List
+                                   [string_jsonschema;
+                                   option_jsonschema string_jsonschema]));
+                              ("unevaluatedItems", (`Bool false));
+                              ("minItems", (`Int 2));
+                              ("maxItems", (`Int 2))])
+                   with
+                   | `Assoc ppx_fields ->
+                       `Assoc
+                         (("default",
+                            (`List
+                               (Stdlib.List.map
+                                  (fun ppx_item ->
+                                     match ppx_item with
+                                     | (ppx_tuple_0, ppx_tuple_1) ->
+                                         `List
+                                           [`String ppx_tuple_0;
+                                           (match ppx_tuple_1 with
+                                            | None -> `Null
+                                            | Some ppx_opt_v ->
+                                                `String ppx_opt_v)])
+                                  [("a", None); ("b", (Some "b"))])))
+                         :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("pair",
+                 (`Assoc
+                    [("default",
+                       ((match (1, "hello") with
+                         | (ppx_tuple_0, ppx_tuple_1) ->
+                             `List [`Int ppx_tuple_0; `String ppx_tuple_1])));
+                    ("type", (`String "array"));
+                    ("prefixItems",
+                      (`List [int_jsonschema; string_jsonschema]));
+                    ("unevaluatedItems", (`Bool false));
+                    ("minItems", (`Int 2));
+                    ("maxItems", (`Int 2))]));
+               ("is_active",
+                 ((match bool_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`Bool false)) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("speed",
+                 ((match float_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`Float 100.0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("label",
+                 ((match string_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`String "default")) ::
+                         ppx_fields)
+                   | ppx_other -> ppx_other)));
+               ("score",
+                 ((match option_jsonschema int_jsonschema with
+                   | `Assoc ppx_fields ->
+                       `Assoc (("default", (`Int 0)) :: ppx_fields)
+                   | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+module Status =
+  struct
+    type t =
+      | Active 
+      | Inactive [@@deriving (to_json, jsonschema)]
+    include
+      struct
+        [@@@ocaml.warning "-39-11-27"]
+        let rec to_json =
+          (fun x ->
+             match x with
+             | Active ->
+                 (Obj.magic [|(Obj.magic "Active" : Js.Json.t)|] : Js.Json.t)
+             | Inactive ->
+                 (Obj.magic [|(Obj.magic "Inactive" : Js.Json.t)|] : 
+                 Js.Json.t) : t -> Js.Json.t)
+        let t_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Active"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "Inactive"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end
+type default_with_module_type =
+  {
+  status: Status.t [@jsonschema.default Status.Active]}[@@deriving
+                                                         jsonschema]
+include
+  struct
+    let default_with_module_type_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("status",
+                  ((match match Status.t_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:458"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (Status.to_json Status.Active)))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type inner_with_option_field = {
+  foo: int option [@option ][@drop_default ]}[@@deriving
+                                               (to_json, jsonschema)]
+include
+  struct
+    [@@@ocaml.warning "-39-11-27"]
+    let rec inner_with_option_field_to_json =
+      (fun x ->
+         match x with
+         | { foo = x_foo } ->
+             (Obj.magic
+                (let module J =
+                   struct
+                     external unsafe_expr :
+                       foo:'a0 -> < foo: 'a0   >  Js.t = "" ""[@@ocaml.warning
+                                                                "-unboxable-type-in-prim-decl"]
+                     [@@mel.internal.ffi
+                       "\132\149\166\190\000\000\000\n\000\000\000\005\000\000\000\012\000\000\000\012\145\160\160A\144#foo@"]
+                   end in
+                   J.unsafe_expr
+                     ~foo:(match x_foo with
+                           | Stdlib.Option.None -> Js.Undefined.empty
+                           | Stdlib.Option.Some _ ->
+                               Js.Undefined.return
+                                 ((option_to_json int_to_json) x_foo))) : 
+             Js.Json.t) : inner_with_option_field -> Js.Json.t)
+    let inner_with_option_field_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc [("foo", (option_jsonschema int_jsonschema))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+let empty_inner_with_option_field : inner_with_option_field = { foo = None }
+type outer_default_record_with_option =
+  {
+  inner: inner_with_option_field [@default empty_inner_with_option_field]}
+[@@deriving jsonschema]
+include
+  struct
+    let outer_default_record_with_option_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("type", (`String "object"));
+          ("properties",
+            (`Assoc
+               [("inner",
+                  ((match match inner_with_option_field_jsonschema with
+                          | `Assoc pairs when
+                              Stdlib.List.mem_assoc "$defs" pairs ->
+                              `Assoc
+                                (("$id",
+                                   (`String "file://shared/cases.ml:467"))
+                                ::
+                                (Stdlib.List.filter
+                                   (fun (k, _) ->
+                                      not (Stdlib.String.equal k "$id"))
+                                   pairs))
+                          | other -> other
+                    with
+                    | `Assoc ppx_fields ->
+                        `Assoc
+                          (("default",
+                             (Ppx_deriving_jsonschema_runtime.classify
+                                (inner_with_option_field_to_json
+                                   empty_inner_with_option_field)))
+                          :: ppx_fields)
+                    | ppx_other -> ppx_other)))]));
+          ("required", (`List []));
+          ("additionalProperties", (`Bool false))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type compact_variants =
+  | A 
+  | B 
+  | C of int [@@deriving jsonschema][@@jsonschema.compact_variants ]
+include
+  struct
+    let compact_variants_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "A"))];
+                `Assoc [("const", (`String "B"))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "C"))]; int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type compact_poly_variants = [ `Aaa  | `Bbb  | `Ccc of int ][@@deriving
+                                                              jsonschema]
+[@@jsonschema.compact_variants ]
+include
+  struct
+    let compact_poly_variants_jsonschema =
+      let ppx_eds = ref [] in
+      let ppx_result =
+        `Assoc
+          [("anyOf",
+             (`List
+                [`Assoc [("const", (`String "Aaa"))];
+                `Assoc [("const", (`String "Bbb"))];
+                `Assoc
+                  [("type", (`String "array"));
+                  ("prefixItems",
+                    (`List
+                       [`Assoc [("const", (`String "Ccc"))]; int_jsonschema]));
+                  ("unevaluatedItems", (`Bool false));
+                  ("minItems", (`Int 2));
+                  ("maxItems", (`Int 2))]]))] in
+      match !ppx_eds with
+      | [] -> ppx_result
+      | ppx_defs ->
+          (match ppx_result with
+           | `Assoc ppx_pairs ->
+               `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                 (Stdlib.List.filter
+                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                    ppx_pairs))
+           | other -> other)[@@warning "-32-39"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+module Generated_code_must_qualify_stdlib =
+  struct
+    module List = struct  end
+    module String = struct  end
+    module Array = struct  end
+    type plain_variant_with_shadowed_stdlib =
+      | A 
+      | B [@name "b"][@@deriving jsonschema]
+    include
+      struct
+        let plain_variant_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "b"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a wrapper_with_shadowed_stdlib =
+      | Wrap of 'a 
+      | Nested of 'a wrapper_with_shadowed_stdlib [@@deriving jsonschema]
+    include
+      struct
+        let wrapper_with_shadowed_stdlib_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_wrapper_with_shadowed_stdlib =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Wrap"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Nested"))];
+                           `Assoc
+                             [("$ref",
+                                (`String
+                                   "#/$defs/wrapper_with_shadowed_stdlib"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("wrapper_with_shadowed_stdlib",
+                      ppx_body_wrapper_with_shadowed_stdlib)]
+                     @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/wrapper_with_shadowed_stdlib"))]
+          [@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type rec_using_wrapper_with_shadowed_stdlib =
+      | Leaf of int 
+      | Node of rec_using_wrapper_with_shadowed_stdlib
+      wrapper_with_shadowed_stdlib [@@deriving jsonschema]
+    include
+      struct
+        let rec_using_wrapper_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_rec_using_wrapper_with_shadowed_stdlib =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "Leaf"))];
+                            int_jsonschema]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           (match wrapper_with_shadowed_stdlib_jsonschema
+                                    (`Assoc
+                                       [("$ref",
+                                          (`String
+                                             "#/$defs/rec_using_wrapper_with_shadowed_stdlib"))])
+                            with
+                            | `Assoc ppx_pairs ->
+                                (match Stdlib.List.assoc_opt "$defs"
+                                         ppx_pairs
+                                 with
+                                 | Some (`Assoc ppx_defs) ->
+                                     (ppx_eds :=
+                                        ((!ppx_eds) @
+                                           (Stdlib.List.filter
+                                              (fun (n, _) ->
+                                                 not
+                                                   (Stdlib.List.mem_assoc n
+                                                      (!ppx_eds))) ppx_defs));
+                                      `Assoc
+                                        (Stdlib.List.filter
+                                           (fun (k, _) ->
+                                              not
+                                                (Stdlib.String.equal k
+                                                   "$defs")) ppx_pairs))
+                                 | _ -> `Assoc ppx_pairs)
+                            | ppx_other -> ppx_other)]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("rec_using_wrapper_with_shadowed_stdlib",
+                      ppx_body_rec_using_wrapper_with_shadowed_stdlib)]
+                     @ (!ppx_eds))));
+            ("$ref",
+              (`String "#/$defs/rec_using_wrapper_with_shadowed_stdlib"))]
+          [@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type record_with_default_with_shadowed_stdlib =
+      {
+      items: int list [@default [1; 2]];
+      items_a: int array [@default [|1;2|]];
+      name: string [@default "x"]}[@@deriving jsonschema]
+    include
+      struct
+        let record_with_default_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("type", (`String "object"));
+              ("properties",
+                (`Assoc
+                   [("name",
+                      ((match string_jsonschema with
+                        | `Assoc ppx_fields ->
+                            `Assoc (("default", (`String "x")) :: ppx_fields)
+                        | ppx_other -> ppx_other)));
+                   ("items_a",
+                     ((match array_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (`List
+                                   (Stdlib.Array.to_list
+                                      (Stdlib.Array.map
+                                         (fun ppx_item -> `Int ppx_item)
+                                         [|1;2|]))))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)));
+                   ("items",
+                     ((match list_jsonschema int_jsonschema with
+                       | `Assoc ppx_fields ->
+                           `Assoc
+                             (("default",
+                                (`List
+                                   (Stdlib.List.map
+                                      (fun ppx_item -> `Int ppx_item) 
+                                      [1; 2])))
+                             :: ppx_fields)
+                       | ppx_other -> ppx_other)))]));
+              ("required", (`List []));
+              ("additionalProperties", (`Bool false))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type non_rec_using_wrapper_with_shadowed_stdlib =
+      int wrapper_with_shadowed_stdlib[@@deriving jsonschema]
+    include
+      struct
+        let non_rec_using_wrapper_with_shadowed_stdlib_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
+            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                `Assoc (("$id", (`String "file://shared/cases.ml:514")) ::
+                  (Stdlib.List.filter
+                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
+            | other -> other in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end
+module Nonrec_type_alias =
+  struct
+    type foo =
+      | A 
+      | B [@@deriving jsonschema]
+    include
+      struct
+        let foo_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_result =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "A"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List [`Assoc [("const", (`String "B"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 1));
+                      ("maxItems", (`Int 1))]]))] in
+          match !ppx_eds with
+          | [] -> ppx_result
+          | ppx_defs ->
+              (match ppx_result with
+               | `Assoc ppx_pairs ->
+                   `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                     (Stdlib.List.filter
+                        (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
+                        ppx_pairs))
+               | other -> other)[@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    module X =
+      struct
+        type nonrec foo = foo[@@deriving jsonschema]
+        include
+          struct
+            let foo_jsonschema =
+              let ppx_eds = ref [] in
+              let ppx_result =
+                match foo_jsonschema with
+                | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
+                    `Assoc (("$id", (`String "file://shared/cases.ml:524"))
+                      ::
+                      (Stdlib.List.filter
+                         (fun (k, _) -> not (Stdlib.String.equal k "$id"))
+                         pairs))
+                | other -> other in
+              match !ppx_eds with
+              | [] -> ppx_result
+              | ppx_defs ->
+                  (match ppx_result with
+                   | `Assoc ppx_pairs ->
+                       `Assoc (("$defs", (`Assoc ppx_defs)) ::
+                         (Stdlib.List.filter
+                            (fun (k, _) ->
+                               not (Stdlib.String.equal k "$defs")) ppx_pairs))
+                   | other -> other)[@@warning "-32-39"]
+          end[@@ocaml.doc "@inline"][@@merlin.hide ]
+      end
+  end
+module Recursive_shapes =
+  struct
+    type a =
+      | A of b 
+    and b = int[@@deriving jsonschema]
+    include
+      struct
+        let a_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/a"))][@@warning "-32-39"]
+        let b_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_a =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List
+                            [`Assoc [("const", (`String "A"))];
+                            `Assoc [("$ref", (`String "#/$defs/b"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))]]))] in
+          let ppx_body_b = int_jsonschema in
+          `Assoc
+            [("$defs",
+               (`Assoc ([("a", ppx_body_a); ("b", ppx_body_b)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/b"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type t =
+      | N 
+      | S of t [@@deriving jsonschema]
+    include
+      struct
+        let t_jsonschema =
+          let ppx_eds = ref [] in
+          let ppx_body_t =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "N"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "S"))];
+                           `Assoc [("$ref", (`String "#/$defs/t"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 2));
+                      ("maxItems", (`Int 2))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("t", ppx_body_t)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/t"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a lst =
+      | Nil 
+      | Cons of 'a * 'a lst [@@deriving jsonschema]
+    include
+      struct
+        let lst_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_lst =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Nil"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Cons"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/lst"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs", (`Assoc ([("lst", ppx_body_lst)] @ (!ppx_eds))));
+            ("$ref", (`String "#/$defs/lst"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+    type 'a tree =
+      | Leaf of 'a 
+      | Node of 'a * 'a forest 
+    and 'a forest =
+      | Empty 
+      | Base of 'a tree * 'a forest [@@deriving jsonschema]
+    include
+      struct
+        let tree_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/tree"))][@@warning "-32-39"]
+        let forest_jsonschema a =
+          let ppx_eds = ref [] in
+          let ppx_body_tree =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Leaf"))]; a]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 2));
+                       ("maxItems", (`Int 2))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Node"))];
+                           a;
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          let ppx_body_forest =
+            `Assoc
+              [("anyOf",
+                 (`List
+                    [`Assoc
+                       [("type", (`String "array"));
+                       ("prefixItems",
+                         (`List [`Assoc [("const", (`String "Empty"))]]));
+                       ("unevaluatedItems", (`Bool false));
+                       ("minItems", (`Int 1));
+                       ("maxItems", (`Int 1))];
+                    `Assoc
+                      [("type", (`String "array"));
+                      ("prefixItems",
+                        (`List
+                           [`Assoc [("const", (`String "Base"))];
+                           `Assoc [("$ref", (`String "#/$defs/tree"))];
+                           `Assoc [("$ref", (`String "#/$defs/forest"))]]));
+                      ("unevaluatedItems", (`Bool false));
+                      ("minItems", (`Int 3));
+                      ("maxItems", (`Int 3))]]))] in
+          `Assoc
+            [("$defs",
+               (`Assoc
+                  ([("tree", ppx_body_tree); ("forest", ppx_body_forest)] @
+                     (!ppx_eds))));
+            ("$ref", (`String "#/$defs/forest"))][@@warning "-32-39"]
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  end

--- a/ppx/jsonschema/test/test_schemas.expected.json
+++ b/ppx/jsonschema/test/test_schemas.expected.json
@@ -1,0 +1,2680 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "C" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "D" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "m2": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "C" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "D" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        },
+        "m": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "B" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      },
+      "required": [ "m2", "m" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Success" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Error" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "skipped" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "const": "Success" }, { "const": "Error" }, { "const": "skipped" }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Aaa" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Bbb" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "ccc" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [ { "const": "Aaa" }, { "const": "Bbb" }, { "const": "ccc" } ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Aaa" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Bbb" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "ccc" }, { "type": "string" }, { "type": "boolean" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 3,
+          "maxItems": 3
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [ { "const": "Aaa" }, { "const": "Bbb" }, { "const": "ccc" } ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "New_one" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Second_one" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Aaa" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Bbb" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "ccc" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "const": "New_one" },
+        { "const": "Second_one" },
+        {
+          "anyOf": [
+            { "const": "Aaa" }, { "const": "Bbb" }, { "const": "ccc" }
+          ]
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "native_int": { "type": "integer" },
+        "unit": { "type": "null" },
+        "string_ref": { "type": "string" },
+        "bunch_of_bytes": { "type": "string" },
+        "c": { "type": "string", "minLength": 1, "maxLength": 1 },
+        "t": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Foo" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Bar" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Baz" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        },
+        "l": { "type": "array", "items": { "type": "string" } },
+        "a": { "type": "array", "items": { "type": "number" } },
+        "opt_int": { "type": [ "integer", "null" ] },
+        "comment": { "type": "string" },
+        "kind_f": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Success" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Error" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "skipped" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        },
+        "date": { "type": "number" }
+      },
+      "required": [
+        "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t", "l",
+        "a", "opt_int", "comment", "kind_f", "date"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "recursive_record": {
+          "type": "object",
+          "properties": {
+            "b": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/recursive_record" }
+            },
+            "a": { "type": "integer" }
+          },
+          "required": [ "b", "a" ],
+          "additionalProperties": false
+        }
+      },
+      "$ref": "#/$defs/recursive_record"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "recursive_variant": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "A" }, { "$ref": "#/$defs/recursive_variant" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "B" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/recursive_variant"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "tree": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Leaf" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Node" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "right": { "$ref": "#/$defs/tree" },
+                    "left": { "$ref": "#/$defs/tree" },
+                    "value": { "type": "integer" }
+                  },
+                  "required": [ "right", "left", "value" ],
+                  "additionalProperties": false
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/tree"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "y": { "type": "string" }, "x": { "type": "integer" } },
+      "required": [ "y", "x" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "foo": {
+          "type": "object",
+          "properties": {
+            "bar": {
+              "anyOf": [ { "$ref": "#/$defs/bar" }, { "type": "null" } ]
+            }
+          },
+          "required": [ "bar" ],
+          "additionalProperties": false
+        },
+        "bar": {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "anyOf": [ { "$ref": "#/$defs/foo" }, { "type": "null" } ]
+            }
+          },
+          "required": [ "foo" ],
+          "additionalProperties": false
+        }
+      },
+      "$ref": "#/$defs/foo"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "foo": {
+          "type": "object",
+          "properties": {
+            "bar": {
+              "anyOf": [ { "$ref": "#/$defs/bar" }, { "type": "null" } ]
+            }
+          },
+          "required": [ "bar" ],
+          "additionalProperties": false
+        },
+        "bar": {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "anyOf": [ { "$ref": "#/$defs/foo" }, { "type": "null" } ]
+            }
+          },
+          "required": [ "foo" ],
+          "additionalProperties": false
+        }
+      },
+      "$ref": "#/$defs/bar"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "expr": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Literal" }, { "type": "integer" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Binary" },
+                { "$ref": "#/$defs/expr" },
+                { "$ref": "#/$defs/expr" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Block" },
+                { "type": "array", "items": { "$ref": "#/$defs/stmt" } }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "stmt": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "ExprStmt" }, { "$ref": "#/$defs/expr" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "IfStmt" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "else_": {
+                      "anyOf": [
+                        { "$ref": "#/$defs/stmt" }, { "type": "null" }
+                      ]
+                    },
+                    "then_": { "$ref": "#/$defs/stmt" },
+                    "cond": { "$ref": "#/$defs/expr" }
+                  },
+                  "required": [ "else_", "then_", "cond" ],
+                  "additionalProperties": false
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/expr"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "x": { "type": "integer" } },
+      "required": [ "x" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "y": { "type": "string" } },
+      "required": [ "y" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "node_a": {
+          "type": "object",
+          "properties": {
+            "c": {
+              "anyOf": [ { "$ref": "#/$defs/node_c" }, { "type": "null" } ]
+            },
+            "b": {
+              "anyOf": [ { "$ref": "#/$defs/node_b" }, { "type": "null" } ]
+            }
+          },
+          "required": [ "c", "b" ],
+          "additionalProperties": false
+        },
+        "node_b": {
+          "type": "object",
+          "properties": {
+            "c": {
+              "anyOf": [ { "$ref": "#/$defs/node_c" }, { "type": "null" } ]
+            },
+            "a": {
+              "anyOf": [ { "$ref": "#/$defs/node_a" }, { "type": "null" } ]
+            }
+          },
+          "required": [ "c", "a" ],
+          "additionalProperties": false
+        },
+        "node_c": {
+          "type": "object",
+          "properties": {
+            "b": {
+              "anyOf": [ { "$ref": "#/$defs/node_b" }, { "type": "null" } ]
+            },
+            "a": {
+              "anyOf": [ { "$ref": "#/$defs/node_a" }, { "type": "null" } ]
+            }
+          },
+          "required": [ "b", "a" ],
+          "additionalProperties": false
+        }
+      },
+      "$ref": "#/$defs/node_a"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "recursive_tuple": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Leaf" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Branch" },
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    { "$ref": "#/$defs/recursive_tuple" },
+                    { "$ref": "#/$defs/recursive_tuple" }
+                  ],
+                  "unevaluatedItems": false,
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/recursive_tuple"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "file://ppx/jsonschema/test/cases.ml:140",
+      "$defs": {
+        "tree": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Leaf" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Node" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "right": { "$ref": "#/$defs/tree" },
+                    "left": { "$ref": "#/$defs/tree" },
+                    "value": { "type": "integer" }
+                  },
+                  "required": [ "right", "left", "value" ],
+                  "additionalProperties": false
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/tree"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "native_int": { "type": "integer" },
+          "unit": { "type": "null" },
+          "string_ref": { "type": "string" },
+          "bunch_of_bytes": { "type": "string" },
+          "c": { "type": "string", "minLength": 1, "maxLength": 1 },
+          "t": {
+            "anyOf": [
+              {
+                "type": "array",
+                "prefixItems": [ { "const": "Foo" } ],
+                "unevaluatedItems": false,
+                "minItems": 1,
+                "maxItems": 1
+              },
+              {
+                "type": "array",
+                "prefixItems": [ { "const": "Bar" } ],
+                "unevaluatedItems": false,
+                "minItems": 1,
+                "maxItems": 1
+              },
+              {
+                "type": "array",
+                "prefixItems": [ { "const": "Baz" } ],
+                "unevaluatedItems": false,
+                "minItems": 1,
+                "maxItems": 1
+              }
+            ]
+          },
+          "l": { "type": "array", "items": { "type": "string" } },
+          "a": { "type": "array", "items": { "type": "number" } },
+          "opt_int": { "type": [ "integer", "null" ] },
+          "comment": { "type": "string" },
+          "kind_f": {
+            "anyOf": [
+              {
+                "type": "array",
+                "prefixItems": [ { "const": "Success" } ],
+                "unevaluatedItems": false,
+                "minItems": 1,
+                "maxItems": 1
+              },
+              {
+                "type": "array",
+                "prefixItems": [ { "const": "Error" } ],
+                "unevaluatedItems": false,
+                "minItems": 1,
+                "maxItems": 1
+              },
+              {
+                "type": "array",
+                "prefixItems": [ { "const": "skipped" } ],
+                "unevaluatedItems": false,
+                "minItems": 1,
+                "maxItems": 1
+              }
+            ]
+          },
+          "date": { "type": "number" }
+        },
+        "required": [
+          "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
+          "l", "a", "opt_int", "comment", "kind_f", "date"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "native_int": { "type": "integer" },
+            "unit": { "type": "null" },
+            "string_ref": { "type": "string" },
+            "bunch_of_bytes": { "type": "string" },
+            "c": { "type": "string", "minLength": 1, "maxLength": 1 },
+            "t": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Foo" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Bar" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Baz" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                }
+              ]
+            },
+            "l": { "type": "array", "items": { "type": "string" } },
+            "a": { "type": "array", "items": { "type": "number" } },
+            "opt_int": { "type": [ "integer", "null" ] },
+            "comment": { "type": "string" },
+            "kind_f": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Success" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Error" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "skipped" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                }
+              ]
+            },
+            "date": { "type": "number" }
+          },
+          "required": [
+            "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
+            "l", "a", "opt_int", "comment", "kind_f", "date"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "object",
+          "properties": {
+            "native_int": { "type": "integer" },
+            "unit": { "type": "null" },
+            "string_ref": { "type": "string" },
+            "bunch_of_bytes": { "type": "string" },
+            "c": { "type": "string", "minLength": 1, "maxLength": 1 },
+            "t": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Foo" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Bar" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Baz" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                }
+              ]
+            },
+            "l": { "type": "array", "items": { "type": "string" } },
+            "a": { "type": "array", "items": { "type": "number" } },
+            "opt_int": { "type": [ "integer", "null" ] },
+            "comment": { "type": "string" },
+            "kind_f": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Success" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Error" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "skipped" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                }
+              ]
+            },
+            "date": { "type": "number" }
+          },
+          "required": [
+            "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
+            "l", "a", "opt_int", "comment", "kind_f", "date"
+          ],
+          "additionalProperties": false
+        },
+        { "type": "string" }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "type": "object",
+            "properties": {
+              "native_int": { "type": "integer" },
+              "unit": { "type": "null" },
+              "string_ref": { "type": "string" },
+              "bunch_of_bytes": { "type": "string" },
+              "c": { "type": "string", "minLength": 1, "maxLength": 1 },
+              "t": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Foo" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Bar" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Baz" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                ]
+              },
+              "l": { "type": "array", "items": { "type": "string" } },
+              "a": { "type": "array", "items": { "type": "number" } },
+              "opt_int": { "type": [ "integer", "null" ] },
+              "comment": { "type": "string" },
+              "kind_f": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Success" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Error" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "skipped" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                ]
+              },
+              "date": { "type": "number" }
+            },
+            "required": [
+              "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
+              "l", "a", "opt_int", "comment", "kind_f", "date"
+            ],
+            "additionalProperties": false
+          },
+          { "type": "string" }
+        ],
+        "unevaluatedItems": false,
+        "minItems": 2,
+        "maxItems": 2
+      }
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "type": "object",
+            "properties": {
+              "native_int": { "type": "integer" },
+              "unit": { "type": "null" },
+              "string_ref": { "type": "string" },
+              "bunch_of_bytes": { "type": "string" },
+              "c": { "type": "string", "minLength": 1, "maxLength": 1 },
+              "t": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Foo" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Bar" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Baz" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                ]
+              },
+              "l": { "type": "array", "items": { "type": "string" } },
+              "a": { "type": "array", "items": { "type": "number" } },
+              "opt_int": { "type": [ "integer", "null" ] },
+              "comment": { "type": "string" },
+              "kind_f": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Success" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "Error" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  },
+                  {
+                    "type": "array",
+                    "prefixItems": [ { "const": "skipped" } ],
+                    "unevaluatedItems": false,
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                ]
+              },
+              "date": { "type": "number" }
+            },
+            "required": [
+              "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
+              "l", "a", "opt_int", "comment", "kind_f", "date"
+            ],
+            "additionalProperties": false
+          },
+          { "type": "integer" }
+        ],
+        "unevaluatedItems": false,
+        "minItems": 2,
+        "maxItems": 2
+      }
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "native_int": { "type": "integer" },
+            "unit": { "type": "null" },
+            "string_ref": { "type": "string" },
+            "bunch_of_bytes": { "type": "string" },
+            "c": { "type": "string", "minLength": 1, "maxLength": 1 },
+            "t": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Foo" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Bar" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Baz" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                }
+              ]
+            },
+            "l": { "type": "array", "items": { "type": "string" } },
+            "a": { "type": "array", "items": { "type": "number" } },
+            "opt_int": { "type": [ "integer", "null" ] },
+            "comment": { "type": "string" },
+            "kind_f": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Success" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "Error" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [ { "const": "skipped" } ],
+                  "unevaluatedItems": false,
+                  "minItems": 1,
+                  "maxItems": 1
+                }
+              ]
+            },
+            "date": { "type": "number" }
+          },
+          "required": [
+            "native_int", "unit", "string_ref", "bunch_of_bytes", "c", "t",
+            "l", "a", "opt_int", "comment", "kind_f", "date"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "integer" }
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": [ "integer", "null" ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "m": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "B" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      },
+      "required": [ "m" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [ { "const": "C" } ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "prefixItems": [
+        { "type": "integer" },
+        {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "second_cstr" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://ahrefs.com/schemas/player_scores",
+      "title": "Player scores",
+      "description": "Object representing player scores",
+      "$defs": {
+        "numbers": { "type": "array", "items": { "type": "integer" } }
+      },
+      "type": "object",
+      "properties": {
+        "scores_ref": { "$ref": "#/$defs/numbers" },
+        "player": { "type": "string" }
+      },
+      "required": [ "scores_ref", "player" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "object",
+          "properties": {
+            "zip": { "type": "string" },
+            "city": { "type": "string" },
+            "street": { "type": "string" }
+          },
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
+        },
+        "email": { "type": [ "string", "null" ] },
+        "age": { "type": "integer" },
+        "name": { "type": "string" }
+      },
+      "required": [ "address", "email", "age", "name" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "shared_address": {
+          "type": "object",
+          "properties": {
+            "zip": { "type": "string" },
+            "city": { "type": "string" },
+            "street": { "type": "string" }
+          },
+          "required": [ "zip", "city", "street" ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "properties": {
+        "retreat_address": { "$ref": "#/$defs/shared_address" },
+        "work_address": { "$ref": "#/$defs/shared_address" },
+        "home_address": { "$ref": "#/$defs/shared_address" },
+        "email": { "type": [ "string", "null" ] },
+        "age": { "type": "integer" },
+        "name": { "type": "string" }
+      },
+      "required": [
+        "retreat_address", "work_address", "home_address", "email", "age",
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [ { "const": "A" }, { "const": "B" } ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "User" },
+            {
+              "type": "object",
+              "properties": {
+                "email": { "type": "string" },
+                "name": { "type": "string" }
+              },
+              "required": [ "email", "name" ],
+              "additionalProperties": true
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Guest" },
+            {
+              "type": "object",
+              "properties": { "ip": { "type": "string" } },
+              "required": [ "ip" ],
+              "additionalProperties": false
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "const": "A" },
+        { "const": "B" },
+        { "const": "C" },
+        { "const": "D" }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Typ" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Class" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [ { "const": "Typ" }, { "const": "Class" } ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "type" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "class" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "prefixItems": [ { "type": "integer" }, { "type": "string" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            { "type": "integer" },
+            { "type": "string" },
+            { "type": "boolean" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 4,
+          "maxItems": 4
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "type": "integer" },
+                { "type": "string" },
+                { "type": "boolean" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            },
+            { "type": "number" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 3,
+          "maxItems": 3
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            { "type": "integer" },
+            { "type": "string" },
+            { "type": "boolean" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 4,
+          "maxItems": 4
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "type": "integer" },
+                { "type": "string" },
+                { "type": "boolean" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "type": "integer" },
+                { "type": "string" },
+                { "type": "boolean" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            },
+            { "type": "number" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 3,
+          "maxItems": 3
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            { "type": "integer" },
+            { "type": "string" },
+            { "type": "boolean" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 4,
+          "maxItems": 4
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "B" },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "type": "integer" },
+                { "type": "string" },
+                { "type": "boolean" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "obj1": {
+          "type": "object",
+          "properties": {
+            "obj2": {
+              "type": "object",
+              "properties": { "x": { "type": "integer" } },
+              "required": [ "x" ],
+              "additionalProperties": true
+            }
+          },
+          "required": [ "obj2" ],
+          "additionalProperties": false
+        }
+      },
+      "required": [ "obj1" ],
+      "additionalProperties": true
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "x": { "type": "integer" } },
+      "required": [ "x" ],
+      "additionalProperties": true
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "title": { "type": [ "string", "null" ] }
+      },
+      "required": [ "url", "title" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "url": { "type": "string" },
+        "title": { "type": [ "string", "null" ] }
+      },
+      "required": [ "url", "title" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "label": { "type": "string" },
+        "second": { "type": "boolean" },
+        "first": { "type": "integer" }
+      },
+      "required": [ "label", "second", "first" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Left" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Right" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Left" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Right" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [ { "const": "North" }, { "const": "South" } ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "max_results": {
+          "description": "Maximum number of results to return",
+          "type": "integer"
+        },
+        "query": {
+          "description": "The search query to execute",
+          "type": "string"
+        }
+      },
+      "required": [ "max_results", "query" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A user object",
+      "type": "object",
+      "properties": {
+        "age": {
+          "description": "The user's age",
+          "type": [ "integer", "null" ]
+        },
+        "name": { "description": "The user's full name", "type": "string" }
+      },
+      "required": [ "name" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "opt_int": {
+          "description": "An optional integer",
+          "type": [ "integer", "null" ]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "No payload",
+          "type": "array",
+          "prefixItems": [ { "const": "Plain" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "description": "Single integer tag",
+          "type": "array",
+          "prefixItems": [ { "const": "With_int" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "description": "String and int",
+          "type": "array",
+          "prefixItems": [
+            { "const": "Pair" }, { "type": "string" }, { "type": "integer" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 3,
+          "maxItems": 3
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Description_value" },
+            { "description": "A string value", "type": "string" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "A 2D point",
+          "type": "array",
+          "prefixItems": [
+            { "const": "Point" },
+            {
+              "type": "object",
+              "properties": {
+                "y": { "type": "integer" },
+                "x": { "type": "integer" }
+              },
+              "required": [ "y", "x" ],
+              "additionalProperties": false
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "description": "First choice", "const": "A" },
+        { "description": "Second choice", "const": "B" }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A user object",
+      "type": "object",
+      "properties": {
+        "age": { "description": "The user's age", "type": "integer" },
+        "name": { "description": "The user's full name", "type": "string" }
+      },
+      "required": [ "age", "name" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "name": { "type": "string" } },
+      "required": [ "name" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "field": { "description": "explicit wins", "type": "string" }
+      },
+      "required": [ "field" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "No payload",
+          "type": "array",
+          "prefixItems": [ { "const": "Plain" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "description": "Single integer tag",
+          "type": "array",
+          "prefixItems": [ { "const": "With_int" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A string alias",
+      "type": "string"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Alias fallback",
+      "type": "string"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The user's full name.\n          Must be non-empty and under 100 characters.",
+          "type": "string"
+        }
+      },
+      "required": [ "name" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "No payload",
+          "type": "array",
+          "prefixItems": [ { "const": "Plain" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "description": "Single integer tag",
+          "type": "array",
+          "prefixItems": [ { "const": "With_int" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "first block\n\nsecond block\n\nthird block",
+      "type": "string"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "description": "explicit wins",
+          "type": "array",
+          "prefixItems": [ { "const": "Tagged" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Either success or an error message string",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Ok" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Err" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "drop_complex": {
+          "anyOf": [
+            { "type": "array", "items": { "type": "integer" } },
+            { "type": "null" }
+          ]
+        },
+        "drop_simple": { "type": [ "string", "null" ] },
+        "plain": { "type": [ "string", "null" ] }
+      },
+      "required": [ "plain" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "custom_drop_default": { "default": 0.0, "type": "number" },
+        "dropped_default": {
+          "default": [],
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "dropped_option": { "type": [ "integer", "null" ] },
+        "default_value": { "default": "-", "type": "string" },
+        "default_none": { "default": null, "type": "string" },
+        "option_default_none": { "default": null, "type": "string" },
+        "option_value": { "type": [ "string", "null" ] },
+        "required_value": { "type": "integer" }
+      },
+      "required": [ "required_value" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "composing_type": {
+          "type": [ "string", "null" ],
+          "description": "A string"
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "format": "date-time",
+      "type": "string"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "with_format": { "format": "date-time", "type": "string" }
+      },
+      "required": [ "with_format" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "A" },
+            {
+              "format": "date-time",
+              "description": "A date-time string",
+              "type": "string"
+            }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "grade": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "B" },
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    { "$ref": "#/$defs/grade" }, { "$ref": "#/$defs/grade" }
+                  ],
+                  "unevaluatedItems": false,
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "C" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/grade"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "b": {
+          "$id": "file://ppx/jsonschema/test/cases.ml:380",
+          "$defs": {
+            "self_ref": {
+              "type": "object",
+              "properties": {
+                "children": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/self_ref" }
+                }
+              },
+              "required": [ "children" ],
+              "additionalProperties": false
+            }
+          },
+          "$ref": "#/$defs/self_ref"
+        },
+        "a": {
+          "$id": "file://ppx/jsonschema/test/cases.ml:379",
+          "$defs": {
+            "self_ref": {
+              "type": "object",
+              "properties": {
+                "children": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/self_ref" }
+                }
+              },
+              "required": [ "children" ],
+              "additionalProperties": false
+            }
+          },
+          "$ref": "#/$defs/self_ref"
+        }
+      },
+      "required": [ "b", "a" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "filter": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Atom" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Group" },
+                { "type": "array", "items": { "$ref": "#/$defs/filter" } },
+                { "type": "string" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/filter"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "outer_rec": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "ORLeaf" }, { "type": "integer" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "ORNode" }, { "$ref": "#/$defs/rec_wrapper" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "rec_wrapper": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "RWrap" }, { "$ref": "#/$defs/outer_rec" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "RNested" }, { "$ref": "#/$defs/rec_wrapper" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/outer_rec"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "bool_filter": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "BoolAtom" },
+                {
+                  "$id": "file://ppx/jsonschema/test/cases.ml:388",
+                  "$defs": {
+                    "filter": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            { "const": "Atom" }, { "type": "integer" }
+                          ],
+                          "unevaluatedItems": false,
+                          "minItems": 2,
+                          "maxItems": 2
+                        },
+                        {
+                          "type": "array",
+                          "prefixItems": [
+                            { "const": "Group" },
+                            {
+                              "type": "array",
+                              "items": { "$ref": "#/$defs/filter" }
+                            },
+                            { "type": "string" }
+                          ],
+                          "unevaluatedItems": false,
+                          "minItems": 3,
+                          "maxItems": 3
+                        }
+                      ]
+                    }
+                  },
+                  "$ref": "#/$defs/filter"
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "BoolFilterGroup" },
+                {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/bool_filter" }
+                }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/bool_filter"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "maximum": 100,
+      "type": "integer"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": { "field": { "maximum": 100, "type": "integer" } },
+      "required": [ "field" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Integer percentage value (0-100 inclusive)",
+      "minimum": 0,
+      "maximum": 100,
+      "type": "integer"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "An ISO date-time",
+          "format": "date-time",
+          "type": "string"
+        },
+        "score": {
+          "description": "Score out of 100",
+          "minimum": 0,
+          "maximum": 100,
+          "type": "integer"
+        }
+      },
+      "required": [ "label", "score" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "A plain integer",
+      "type": "integer"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0,
+      "maximum": 100,
+      "type": "integer"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "type": "number"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "ratio": { "minimum": 0.0, "maximum": 1.0, "type": "number" },
+        "score": { "minimum": 0, "maximum": 100, "type": "integer" }
+      },
+      "required": [ "ratio", "score" ],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0,
+      "maximum": 255,
+      "type": "integer"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "type": "number"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Percentage" },
+            { "minimum": 0, "maximum": 100, "type": "integer" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        {
+          "type": "array",
+          "prefixItems": [
+            { "const": "Factor" },
+            { "minimum": 0.0, "maximum": 1.0, "type": "number" }
+          ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "range": {
+          "default": { "from": 0, "to": 100 },
+          "type": "object",
+          "properties": {
+            "to": { "type": "integer" },
+            "from": { "type": "integer" }
+          },
+          "required": [ "to", "from" ],
+          "additionalProperties": false
+        },
+        "empty_list": {
+          "default": [],
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "int_list": {
+          "default": [ 1, 2, 3 ],
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "record": {
+          "default": { "score": null },
+          "type": "object",
+          "properties": { "score": { "type": [ "integer", "null" ] } },
+          "required": [ "score" ],
+          "additionalProperties": false
+        },
+        "variant": {
+          "default": [ "A" ],
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "B" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        },
+        "pairs": {
+          "default": [ [ "a", null ], [ "b", "b" ] ],
+          "type": "array",
+          "items": {
+            "type": "array",
+            "prefixItems": [
+              { "type": "string" }, { "type": [ "string", "null" ] }
+            ],
+            "unevaluatedItems": false,
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "pair": {
+          "default": [ 1, "hello" ],
+          "type": "array",
+          "prefixItems": [ { "type": "integer" }, { "type": "string" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "is_active": { "default": false, "type": "boolean" },
+        "speed": { "default": 100.0, "type": "number" },
+        "label": { "default": "default", "type": "string" },
+        "score": { "default": 0, "type": [ "integer", "null" ] }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "status": {
+          "default": [ "Active" ],
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Active" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Inactive" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            }
+          ]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "inner": {
+          "default": {},
+          "type": "object",
+          "properties": { "foo": { "type": [ "integer", "null" ] } },
+          "required": [],
+          "additionalProperties": false
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "const": "A" },
+        { "const": "B" },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "C" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        { "const": "Aaa" },
+        { "const": "Bbb" },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "Ccc" }, { "type": "integer" } ],
+          "unevaluatedItems": false,
+          "minItems": 2,
+          "maxItems": 2
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "A" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        },
+        {
+          "type": "array",
+          "prefixItems": [ { "const": "B" } ],
+          "unevaluatedItems": false,
+          "minItems": 1,
+          "maxItems": 1
+        }
+      ]
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "a": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" }, { "$ref": "#/$defs/b" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "b": { "type": "integer" }
+      },
+      "$ref": "#/$defs/a"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "a": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "A" }, { "$ref": "#/$defs/b" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        },
+        "b": { "type": "integer" }
+      },
+      "$ref": "#/$defs/b"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "t": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "N" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "S" }, { "$ref": "#/$defs/t" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/t"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "lst": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Nil" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Cons" },
+                { "type": "integer" },
+                { "$ref": "#/$defs/lst" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/lst"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "tree": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Leaf" }, { "type": "string" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Node" },
+                { "type": "string" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        },
+        "forest": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Empty" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Base" },
+                { "$ref": "#/$defs/tree" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/tree"
+    },
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$defs": {
+        "tree": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Leaf" }, { "type": "string" } ],
+              "unevaluatedItems": false,
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Node" },
+                { "type": "string" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        },
+        "forest": {
+          "anyOf": [
+            {
+              "type": "array",
+              "prefixItems": [ { "const": "Empty" } ],
+              "unevaluatedItems": false,
+              "minItems": 1,
+              "maxItems": 1
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                { "const": "Base" },
+                { "$ref": "#/$defs/tree" },
+                { "$ref": "#/$defs/forest" }
+              ],
+              "unevaluatedItems": false,
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "$ref": "#/$defs/forest"
+    }
+  ]
+}

--- a/ppx/jsonschema/test/test_sig.t
+++ b/ppx/jsonschema/test/test_sig.t
@@ -1,0 +1,66 @@
+  $ cat > test_sig.mli << 'EOF'
+  > type event = {
+  >   name : string;
+  >   count : int;
+  > }
+  > [@@deriving jsonschema]
+  > 
+  > type kind =
+  >   | Success
+  >   | Error
+  > [@@deriving jsonschema]
+  > 
+  > type alias = event [@@deriving jsonschema]
+  > 
+  > type 'a wrapper = { value : 'a } [@@deriving jsonschema]
+  > 
+  > type ('a, 'b) pair = {
+  >   first : 'a;
+  >   second : 'b;
+  > }
+  > [@@deriving jsonschema]
+  > 
+  > type foo = { bar : bar option }
+  > and bar = { foo : foo option }
+  > [@@deriving jsonschema]
+  > EOF
+  $ ./pp.exe -deriving-keep-w32 both --intf test_sig.mli -o test_sig_out.mli && cat test_sig_out.mli
+  type event = {
+    name: string ;
+    count: int }[@@deriving jsonschema]
+  include sig val event_jsonschema : Ppx_deriving_jsonschema_runtime.t end
+  [@@ocaml.doc "@inline"][@@merlin.hide ]
+  type kind =
+    | Success 
+    | Error [@@deriving jsonschema]
+  include sig val kind_jsonschema : Ppx_deriving_jsonschema_runtime.t end
+  [@@ocaml.doc "@inline"][@@merlin.hide ]
+  type alias = event[@@deriving jsonschema]
+  include sig val alias_jsonschema : Ppx_deriving_jsonschema_runtime.t end
+  [@@ocaml.doc "@inline"][@@merlin.hide ]
+  type 'a wrapper = {
+    value: 'a }[@@deriving jsonschema]
+  include
+    sig
+      val wrapper_jsonschema :
+        Ppx_deriving_jsonschema_runtime.t -> Ppx_deriving_jsonschema_runtime.t
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  type ('a, 'b) pair = {
+    first: 'a ;
+    second: 'b }[@@deriving jsonschema]
+  include
+    sig
+      val pair_jsonschema :
+        Ppx_deriving_jsonschema_runtime.t ->
+          Ppx_deriving_jsonschema_runtime.t ->
+            Ppx_deriving_jsonschema_runtime.t
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+  type foo = {
+    bar: bar option }
+  and bar = {
+    foo: foo option }[@@deriving jsonschema]
+  include
+    sig
+      val foo_jsonschema : Ppx_deriving_jsonschema_runtime.t
+      val bar_jsonschema : Ppx_deriving_jsonschema_runtime.t
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/ppx/jsonschema/test/wire.ml
+++ b/ppx/jsonschema/test/wire.ml
@@ -1,0 +1,502 @@
+(* Wire test: for types that derive BOTH [to_json] and [jsonschema], check that
+   the JSON produced by melange-json's encoder actually validates against the
+   generated JSON Schema.
+
+   The two derivers share melange-json's attributes ([@key], [@option],
+   [@default], [@name], [@@compact_variants], ...), so the schema is supposed to
+   describe exactly the wire shape the encoder emits. This test enforces that
+   contract by round-tripping sample values through [_to_json] and validating
+   the result against [_jsonschema] with an external Draft 2020-12 validator
+   ([check-jsonschema]). *)
+
+open Ppx_deriving_jsonschema_runtime.Primitives.Melange_json
+open Melange_json.Primitives
+
+type json = Yojson.Basic.t
+
+let schema_of ?definitions (s : Ppx_deriving_jsonschema_runtime.t) : json
+    =
+  (Ppx_deriving_jsonschema_runtime.json_schema ?definitions s :> json)
+
+type case = { name : string; schema : json; instances : json list }
+
+let case name schema instances = { name; schema; instances }
+
+type simple_record = { name : string; age : int; email : string option }
+[@@deriving to_json, jsonschema]
+
+let simple_record =
+  case "simple_record"
+    (schema_of simple_record_jsonschema)
+    [
+      simple_record_to_json
+        { name = "Ada"; age = 36; email = Some "ada@x.dev" };
+      simple_record_to_json { name = "Bob"; age = 0; email = None };
+    ]
+
+type defaults_record = {
+  required_value : int;
+  option_value : string option; [@option]
+  default_value : string; [@default "-"]
+}
+[@@deriving to_json, jsonschema]
+
+let defaults_record =
+  case "defaults_record"
+    (schema_of defaults_record_jsonschema)
+    [
+      defaults_record_to_json
+        {
+          required_value = 1;
+          option_value = Some "hi";
+          default_value = "custom";
+        };
+      defaults_record_to_json
+        { required_value = 2; option_value = None; default_value = "-" };
+    ]
+
+type keyed_record = { from : int; to_ : int [@key "to"] }
+[@@deriving to_json, jsonschema]
+
+let keyed_record =
+  case "keyed_record"
+    (schema_of keyed_record_jsonschema)
+    [ keyed_record_to_json { from = 0; to_ = 100 } ]
+
+type kind = Success | Error | Skipped [@name "skipped"]
+[@@deriving to_json, jsonschema]
+
+let kind =
+  case "kind"
+    (schema_of kind_jsonschema)
+    [ kind_to_json Success; kind_to_json Error; kind_to_json Skipped ]
+
+type payload_variant =
+  | Nullary
+  | Single of int
+  | Pair of int * string
+  | Inline of { label : string }
+[@@deriving to_json, jsonschema]
+
+let payload_variant =
+  case "payload_variant"
+    (schema_of payload_variant_jsonschema)
+    [
+      payload_variant_to_json Nullary;
+      payload_variant_to_json (Single 7);
+      payload_variant_to_json (Pair (1, "x"));
+      payload_variant_to_json (Inline { label = "l" });
+    ]
+
+type compact_variant = A | B | C of int
+[@@deriving to_json, jsonschema] [@@compact_variants]
+
+let compact_variant =
+  case "compact_variant"
+    (schema_of compact_variant_jsonschema)
+    [
+      `List [ `String "A" ];
+      compact_variant_to_json A;
+      compact_variant_to_json B;
+      compact_variant_to_json (C 3);
+    ]
+
+type poly_variant = [ `Aaa | `Bbb of int ]
+[@@deriving to_json, jsonschema]
+
+let poly_variant =
+  case "poly_variant"
+    (schema_of poly_variant_jsonschema)
+    [ poly_variant_to_json `Aaa; poly_variant_to_json (`Bbb 9) ]
+
+type pair = int * string [@@deriving to_json, jsonschema]
+
+let pair =
+  case "pair" (schema_of pair_jsonschema) [ pair_to_json (1, "one") ]
+
+type address = { street : string; city : string }
+[@@deriving to_json, jsonschema]
+
+type nested = { who : simple_record; where : address }
+[@@deriving to_json, jsonschema]
+
+let nested =
+  case "nested"
+    (schema_of nested_jsonschema)
+    [
+      nested_to_json
+        {
+          who = { name = "Ada"; age = 36; email = None };
+          where = { street = "1 Main"; city = "Town" };
+        };
+    ]
+
+type tree = Leaf | Node of { value : int; left : tree; right : tree }
+[@@deriving to_json, jsonschema]
+
+let tree =
+  case "tree"
+    (schema_of tree_jsonschema)
+    [
+      tree_to_json Leaf;
+      tree_to_json
+        (Node
+           {
+             value = 1;
+             left = Leaf;
+             right = Node { value = 2; left = Leaf; right = Leaf };
+           });
+    ]
+
+type containers = { numbers : int list; flags : bool array }
+[@@deriving to_json, jsonschema]
+
+let containers =
+  case "containers"
+    (schema_of containers_jsonschema)
+    [
+      containers_to_json
+        { numbers = [ 1; 2; 3 ]; flags = [| true; false |] };
+    ]
+
+type primitives = {
+  ratio : float;
+  active : bool;
+  big : int64;
+  nothing : unit;
+}
+[@@deriving to_json, jsonschema]
+
+let primitives =
+  case "primitives"
+    (schema_of primitives_jsonschema)
+    [
+      primitives_to_json
+        { ratio = 1.5; active = true; big = 9_000_000_000L; nothing = () };
+    ]
+
+type outcome = (int, string) result [@@deriving to_json, jsonschema]
+
+let outcome =
+  case "outcome"
+    (schema_of outcome_jsonschema)
+    [ outcome_to_json (Ok 1); outcome_to_json (Error "nope") ]
+
+type optionals = {
+  maybe_list : int list option;
+  maybe_pair : (int * string) option;
+}
+[@@deriving to_json, jsonschema]
+
+let optionals =
+  case "optionals"
+    (schema_of optionals_jsonschema)
+    [
+      optionals_to_json
+        { maybe_list = Some [ 1; 2 ]; maybe_pair = Some (3, "x") };
+      optionals_to_json { maybe_list = None; maybe_pair = None };
+    ]
+
+type matrix = int list list [@@deriving to_json, jsonschema]
+
+let matrix =
+  case "matrix"
+    (schema_of matrix_jsonschema)
+    [ matrix_to_json [ [ 1; 2 ]; []; [ 3 ] ] ]
+
+type labeled = (int * string) list [@@deriving to_json, jsonschema]
+
+let labeled =
+  case "labeled"
+    (schema_of labeled_jsonschema)
+    [ labeled_to_json [ 1, "a"; 2, "b" ] ]
+
+type person = { name : string; age : int }
+[@@deriving to_json, jsonschema]
+
+type roster = person array [@@deriving to_json, jsonschema]
+
+let roster =
+  case "roster"
+    (schema_of roster_jsonschema)
+    [
+      roster_to_json
+        [| { name = "Ada"; age = 36 }; { name = "Bob"; age = 1 } |];
+    ]
+
+type numbers = int list [@@deriving to_json, jsonschema]
+
+type player_scores = {
+  player : string;
+  scores : numbers; [@ref "numbers"] [@key "scores_ref"]
+}
+[@@deriving to_json, jsonschema]
+
+let player_scores =
+  case "player_scores"
+    (schema_of
+       ~definitions:[ "numbers", numbers_jsonschema ]
+       player_scores_jsonschema)
+    [ player_scores_to_json { player = "Ada"; scores = [ 10; 20; 30 ] } ]
+
+type addr = { street : string; city : string }
+[@@deriving to_json, jsonschema]
+
+type contact = {
+  home_address : addr; [@ref "shared_address"]
+  work_address : addr; [@ref "shared_address"]
+}
+[@@deriving to_json, jsonschema]
+
+let contact =
+  case "contact"
+    (schema_of
+       ~definitions:[ "shared_address", addr_jsonschema ]
+       contact_jsonschema)
+    [
+      contact_to_json
+        {
+          home_address = { street = "1 Main"; city = "Town" };
+          work_address = { street = "2 Side"; city = "City" };
+        };
+    ]
+
+type foo = { bar : bar option }
+and bar = { foo : foo option } [@@deriving to_json, jsonschema]
+
+let foo =
+  case "foo"
+    (schema_of foo_jsonschema)
+    [
+      foo_to_json { bar = None };
+      foo_to_json { bar = Some { foo = Some { bar = None } } };
+    ]
+
+type recursive_tuple =
+  | Leaf' of int
+  | Branch of (recursive_tuple * recursive_tuple)
+[@@deriving to_json, jsonschema]
+
+let recursive_tuple =
+  case "recursive_tuple"
+    (schema_of recursive_tuple_jsonschema)
+    [
+      recursive_tuple_to_json (Leaf' 1);
+      recursive_tuple_to_json
+        (Branch (Leaf' 1, Branch (Leaf' 2, Leaf' 3)));
+    ]
+
+(* Polymorphic variants with payloads, tuple payloads, and inheritance. *)
+type poly_payload = [ `Aaa of int | `Bbb | `Ccc of string * bool ]
+[@@deriving to_json, jsonschema]
+
+let poly_payload =
+  case "poly_payload"
+    (schema_of poly_payload_jsonschema)
+    [
+      poly_payload_to_json (`Aaa 1);
+      poly_payload_to_json `Bbb;
+      poly_payload_to_json (`Ccc ("x", true));
+    ]
+
+type poly_base = [ `Aaa | `Bbb ] [@@deriving to_json, jsonschema]
+
+type poly_inherit = [ `New_one | `Second_one of int | poly_base ]
+[@@deriving to_json, jsonschema]
+
+let poly_inherit =
+  case "poly_inherit"
+    (schema_of poly_inherit_jsonschema)
+    [
+      poly_inherit_to_json `New_one;
+      poly_inherit_to_json (`Second_one 2);
+      poly_inherit_to_json `Aaa;
+      poly_inherit_to_json `Bbb;
+    ]
+
+type ('a, 'b) either = Left of 'a | Right of 'b
+[@@deriving to_json, jsonschema]
+
+let either =
+  case "either"
+    (schema_of (either_jsonschema int_jsonschema string_jsonschema))
+    [
+      either_to_json int_to_json string_to_json (Left 1);
+      either_to_json int_to_json string_to_json (Right "r");
+    ]
+
+type 'url link = { title : string option; url : 'url }
+[@@deriving to_json, jsonschema]
+
+let link =
+  case "link"
+    (schema_of (link_jsonschema string_jsonschema))
+    [
+      link_to_json string_to_json { title = Some "t"; url = "http://x" };
+      link_to_json string_to_json { title = None; url = "http://y" };
+    ]
+
+type bounded = {
+  score : int; [@jsonschema.minimum 0] [@jsonschema.maximum 100]
+  fraction : float; [@jsonschema.minimum 0.0] [@jsonschema.maximum 1.0]
+}
+[@@deriving to_json, jsonschema]
+
+let bounded =
+  case "bounded"
+    (schema_of bounded_jsonschema)
+    [
+      bounded_to_json { score = 0; fraction = 0.0 };
+      bounded_to_json { score = 100; fraction = 1.0 };
+      bounded_to_json { score = 50; fraction = 0.5 };
+    ]
+
+type timestamped = { at : string [@jsonschema.format "date-time"] }
+[@@deriving to_json, jsonschema]
+
+let timestamped =
+  case "timestamped"
+    (schema_of timestamped_jsonschema)
+    [ timestamped_to_json { at = "2020-01-02T03:04:05Z" } ]
+
+type annotated = {
+  note : string option; [@jsonschema.option]
+  weight : int; [@jsonschema.default 1]
+}
+[@@deriving to_json, jsonschema]
+
+let annotated =
+  case "annotated"
+    (schema_of annotated_jsonschema)
+    [
+      annotated_to_json { note = Some "hi"; weight = 5 };
+      annotated_to_json { note = None; weight = 1 };
+    ]
+
+type named_variant =
+  | Typ [@name "type"]
+  | Klass of string [@name "class"]
+[@@deriving to_json, jsonschema]
+
+let named_variant =
+  case "named_variant"
+    (schema_of named_variant_jsonschema)
+    [ named_variant_to_json Typ; named_variant_to_json (Klass "k") ]
+
+type named_poly = [ `Aaa | `Ccc of int [@name "ccc"] ]
+[@@deriving to_json, jsonschema]
+
+let named_poly =
+  case "named_poly"
+    (schema_of named_poly_jsonschema)
+    [ named_poly_to_json `Aaa; named_poly_to_json (`Ccc 3) ]
+
+type key_opt = { opt : int option [@key "opt_int"] [@option] }
+[@@deriving to_json, jsonschema]
+
+let key_opt =
+  case "key_opt"
+    (schema_of key_opt_jsonschema)
+    [ key_opt_to_json { opt = Some 5 }; key_opt_to_json { opt = None } ]
+
+let cases : case list =
+  [
+    simple_record;
+    defaults_record;
+    keyed_record;
+    kind;
+    payload_variant;
+    compact_variant;
+    poly_variant;
+    pair;
+    nested;
+    tree;
+    containers;
+    primitives;
+    outcome;
+    optionals;
+    matrix;
+    labeled;
+    roster;
+    player_scores;
+    contact;
+    foo;
+    recursive_tuple;
+    poly_payload;
+    poly_inherit;
+    either;
+    link;
+    bounded;
+    timestamped;
+    annotated;
+    named_variant;
+    named_poly;
+    key_opt;
+  ]
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let read_all ic =
+  let buf = Buffer.create 256 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 1
+     done
+   with End_of_file -> ());
+  Buffer.contents buf
+
+let validate ~schema_file ~instance_file =
+  let cmd =
+    Filename.quote_command "check-jsonschema"
+      [ "--schemafile"; schema_file; instance_file ]
+  in
+  let ic = Unix.open_process_in (cmd ^ " 2>&1") in
+  let output = read_all ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok ()
+  | Unix.WEXITED 127 ->
+      Error
+        "check-jsonschema not found on PATH (install it to run this test)"
+  | _ ->
+      let cleaned =
+        String.split_on_char '\n' output
+        |> List.map (fun line ->
+            match String.index_opt line ':' with
+            (* remove the file prefix from the error message for a clear output *)
+            | Some i when String.length line > i + 1 && line.[i + 1] = ':'
+              ->
+                ""
+            | _ -> line)
+        |> String.concat "\n"
+      in
+      Error (String.trim cleaned)
+
+let () =
+  let schema_file = "wire_schema.json" in
+  let instance_file = "wire_instance.json" in
+  let failures = ref 0 in
+  List.iter
+    (fun { name; schema; instances } ->
+      write_file schema_file (Yojson.Basic.to_string schema);
+      let total = List.length instances in
+      let ok = ref 0 in
+      List.iteri
+        (fun i instance ->
+          write_file instance_file (Yojson.Basic.to_string instance);
+          match validate ~schema_file ~instance_file with
+          | Ok () -> incr ok
+          | Error msg ->
+              incr failures;
+              Printf.printf "%s: %s.[%d] is INVALID\nValue: %s\n%s\n" name
+                name i
+                (Yojson.Basic.to_string instance)
+                msg)
+        instances;
+      if !ok = total then Printf.printf "%s: %d/%d valid\n" name !ok total)
+    cases;
+  (try Sys.remove schema_file with Sys_error _ -> ());
+  (try Sys.remove instance_file with Sys_error _ -> ());
+  if !failures > 0 then exit 1

--- a/ppx/jsonschema/test/wire.t
+++ b/ppx/jsonschema/test/wire.t
@@ -1,0 +1,36 @@
+Wire test: JSON produced by melange-json's [to_json] encoder must validate
+against the schema produced by the [jsonschema] deriver for the same type.
+Requires the [check-jsonschema] CLI on PATH.
+
+  $ ./wire.exe
+  simple_record: 2/2 valid
+  defaults_record: 2/2 valid
+  keyed_record: 1/1 valid
+  kind: 3/3 valid
+  payload_variant: 4/4 valid
+  compact_variant: 3/3 valid
+  poly_variant: 2/2 valid
+  pair: 1/1 valid
+  nested: 1/1 valid
+  tree: 2/2 valid
+  containers: 1/1 valid
+  primitives: 1/1 valid
+  outcome: 2/2 valid
+  optionals: 2/2 valid
+  matrix: 1/1 valid
+  labeled: 1/1 valid
+  roster: 1/1 valid
+  player_scores: 1/1 valid
+  contact: 1/1 valid
+  foo: 2/2 valid
+  recursive_tuple: 2/2 valid
+  poly_payload: 3/3 valid
+  poly_inherit: 4/4 valid
+  either: 2/2 valid
+  link: 2/2 valid
+  bounded: 3/3 valid
+  timestamped: 1/1 valid
+  annotated: 2/2 valid
+  named_variant: 2/2 valid
+  named_poly: 2/2 valid
+  key_opt: 2/2 valid

--- a/ppx/native/dune
+++ b/ppx/native/dune
@@ -3,7 +3,10 @@
  (name ppx_deriving_json_native)
  (modules :standard \ ppx_deriving_json_native_test)
  (libraries ppxlib)
- (ppx_runtime_libraries melange-json-native yojson)
+ (ppx_runtime_libraries
+  melange-json-native
+  yojson
+  melange-json-native.jsonschema)
  (preprocess
   (pps ppxlib.metaquot))
  (kind ppx_deriver))
@@ -32,6 +35,13 @@
 
 (copy_files#
  (files ./common/ppx_deriving_tools.{ml,mli}))
+
+; The jsonschema deriver is shared between the native and browser ppx (it is
+; platform-agnostic: it only emits references to Ppx_deriving_jsonschema_runtime).
+; Like the common modules above, the sources are copied in rather than shared via
+; a library, so the deriver ships inside melange-json-native.ppx with no extra package.
+(copy_files#
+ (files ../jsonschema/{attrs,schema,ppx_deriving_jsonschema}.{ml,mli}))
 
 ; include_subdirs triggers a dependency cycle
 ; $ dune runtest

--- a/ppx/native/ppx_deriving_json_native.ml
+++ b/ppx/native/ppx_deriving_json_native.ml
@@ -374,4 +374,5 @@ let () =
   let (_ : Deriving.t) = Of_json_string.register ~of_json () in
   let (_ : Deriving.t) = To_json_string.register ~to_json () in
   let (_ : Deriving.t) = Json_string.register ~json () in
+  let (_ : Deriving.t) = Ppx_deriving_jsonschema.register () in
   ()

--- a/src/jsonschema/Ppx_deriving_jsonschema_runtime_classify.ml
+++ b/src/jsonschema/Ppx_deriving_jsonschema_runtime_classify.ml
@@ -1,0 +1,47 @@
+type t =
+  [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of t list
+  | `Assoc of (string * t) list
+  ]
+
+(* [Js.Json.classify] only checks for [=== null] when distinguishing null from object, so it
+   mis-classifies [undefined] as [JSONObject]. melange-json's [@option] [@drop_default] codegen
+   emits [Js.Undefined.empty] for [None], so an [_to_json] result can legitimately contain
+   [undefined] values that we have to handle here. We treat them as absent fields, matching
+   [JSON.stringify] (which drops undefined object members and turns undefined array elements
+   into null). *)
+let classify value =
+  let rec decode json =
+    match Js.Json.classify json with
+    | JSONNull -> `Null
+    | JSONString s -> `String s
+    | JSONNumber n ->
+      let i = int_of_float n in
+      if float_of_int i = n then `Int i else `Float n
+    | JSONFalse -> `Bool false
+    | JSONTrue -> `Bool true
+    | JSONArray arr -> `List (Array.to_list (Array.map decode arr))
+    | JSONObject dict ->
+      let is_undefined json = Js.typeof json = "undefined" in
+      `Assoc
+        (Array.fold_right
+           (fun (k, v) acc -> if is_undefined v then acc else (k, decode v) :: acc)
+           (Js.Dict.entries dict) [])
+  in
+  decode value
+
+let declassify value =
+  let rec encode = function
+    | `Null -> Js.Json.null
+    | `String str -> Js.Json.string str
+    | `Float f -> Js.Json.number f
+    | `Int i -> Js.Json.number (Js.Int.toFloat i)
+    | `Bool b -> Js.Json.boolean b
+    | `List li -> Js.Json.array (Array.of_list (List.map encode li))
+    | `Assoc assoc -> Js.Json.object_ (Js.Dict.fromList (List.map (fun (k, v) -> k, encode v) assoc))
+  in
+  encode value

--- a/src/jsonschema/dune
+++ b/src/jsonschema/dune
@@ -1,0 +1,8 @@
+; Melange runtime for [@@deriving jsonschema] (part of the melange-json package).
+; The native counterpart lives in ../native/jsonschema and shares the
+; platform-neutral sources via copy_files.
+(library
+ (name ppx_deriving_jsonschema_runtime)
+ (public_name melange-json.jsonschema)
+ (modes melange)
+ (wrapped false))

--- a/src/jsonschema/ppx_deriving_jsonschema_runtime.ml
+++ b/src/jsonschema/ppx_deriving_jsonschema_runtime.ml
@@ -1,0 +1,35 @@
+let schema_version = "https://json-schema.org/draft/2020-12/schema"
+
+type t = Ppx_deriving_jsonschema_runtime_classify.t
+
+let classify = Ppx_deriving_jsonschema_runtime_classify.classify
+let declassify = Ppx_deriving_jsonschema_runtime_classify.declassify
+
+let json_schema ?id ?title ?description ?definitions types =
+  let fields =
+    match types with
+    | `Assoc fields -> fields
+    | _ -> []
+  in
+  let metadata =
+    List.filter_map
+      (fun x -> x)
+      [
+        Some ("$schema", `String schema_version);
+        (match id with
+        | None -> None
+        | Some id -> Some ("$id", `String id));
+        (match title with
+        | None -> None
+        | Some title -> Some ("title", `String title));
+        (match description with
+        | None -> None
+        | Some description -> Some ("description", `String description));
+        (match definitions with
+        | None -> None
+        | Some defs -> Some ("$defs", `Assoc defs));
+      ]
+  in
+  `Assoc (metadata @ fields)
+
+module Primitives = Ppx_deriving_jsonschema_runtime_primitives

--- a/src/jsonschema/ppx_deriving_jsonschema_runtime.mli
+++ b/src/jsonschema/ppx_deriving_jsonschema_runtime.mli
@@ -1,0 +1,10 @@
+val schema_version : string
+
+type t = Ppx_deriving_jsonschema_runtime_classify.t
+
+val classify : Js.Json.t -> t
+val declassify : t -> Js.Json.t
+
+val json_schema : ?id:string -> ?title:string -> ?description:string -> ?definitions:(string * t) list -> t -> t
+
+module Primitives : module type of Ppx_deriving_jsonschema_runtime_primitives

--- a/src/jsonschema/ppx_deriving_jsonschema_runtime_primitives.ml
+++ b/src/jsonschema/ppx_deriving_jsonschema_runtime_primitives.ml
@@ -1,0 +1,79 @@
+module Common = struct
+  type t = Ppx_deriving_jsonschema_runtime_classify.t
+
+  let char_jsonschema : t =
+    `Assoc
+      [
+        "type", `String "string"; "minLength", `Int 1; "maxLength", `Int 1;
+      ]
+
+  let string_jsonschema : t = `Assoc [ "type", `String "string" ]
+  let bool_jsonschema : t = `Assoc [ "type", `String "boolean" ]
+  let float_jsonschema : t = `Assoc [ "type", `String "number" ]
+  let int_jsonschema : t = `Assoc [ "type", `String "integer" ]
+
+  let option_jsonschema (schema : t) : t =
+    let is_basic_type ty =
+      ty = "string" || ty = "number" || ty = "boolean" || ty = "integer"
+    in
+    match schema with
+    | `Assoc (("type", `String ty) :: rest) when is_basic_type ty ->
+        `Assoc (("type", `List [ `String ty; `String "null" ]) :: rest)
+    | s ->
+        `Assoc [ "anyOf", `List [ s; `Assoc [ "type", `String "null" ] ] ]
+
+  let unit_jsonschema : t = `Assoc [ "type", `String "null" ]
+
+  let list_jsonschema element_type : t =
+    `Assoc [ "type", `String "array"; "items", element_type ]
+
+  let array_jsonschema element_type : t =
+    `Assoc [ "type", `String "array"; "items", element_type ]
+end
+
+module Yojson = struct
+  include Common
+
+  let int64_jsonschema : t = `Assoc [ "type", `String "integer" ]
+end
+
+module Melange_json = struct
+  include Common
+
+  let int64_jsonschema : t =
+    `Assoc
+      [
+        "type", `String "string";
+        "description", `String "int64 is represented as a string";
+      ]
+
+  let result_jsonschema (ok_schema : t) (error_schema : t) : t =
+    `Assoc
+      [
+        ( "anyOf",
+          `List
+            [
+              `Assoc
+                [
+                  "type", `String "array";
+                  ( "prefixItems",
+                    `List
+                      [
+                        `Assoc [ "const", `String "Error" ]; error_schema;
+                      ] );
+                  "unevaluatedItems", `Bool false;
+                  "minItems", `Int 1;
+                ];
+              `Assoc
+                [
+                  "type", `String "array";
+                  ( "prefixItems",
+                    `List [ `Assoc [ "const", `String "Ok" ]; ok_schema ]
+                  );
+                  "unevaluatedItems", `Bool false;
+                  "minItems", `Int 2;
+                  "maxItems", `Int 2;
+                ];
+            ] );
+      ]
+end

--- a/src/jsonschema/ppx_deriving_jsonschema_runtime_primitives.mli
+++ b/src/jsonschema/ppx_deriving_jsonschema_runtime_primitives.mli
@@ -1,0 +1,28 @@
+module Yojson : sig
+  type t = Ppx_deriving_jsonschema_runtime_classify.t
+  val char_jsonschema : t
+  val string_jsonschema : t
+  val bool_jsonschema : t
+  val float_jsonschema : t
+  val int_jsonschema : t
+  val option_jsonschema : t -> t
+  val unit_jsonschema : t
+  val list_jsonschema : t -> t
+  val array_jsonschema : t -> t
+  val int64_jsonschema : t
+end
+
+module Melange_json : sig
+  type t = Ppx_deriving_jsonschema_runtime_classify.t
+  val char_jsonschema : t
+  val string_jsonschema : t
+  val bool_jsonschema : t
+  val float_jsonschema : t
+  val int_jsonschema : t
+  val option_jsonschema : t -> t
+  val unit_jsonschema : t
+  val list_jsonschema : t -> t
+  val array_jsonschema : t -> t
+  val int64_jsonschema : t
+  val result_jsonschema : t -> t -> t
+end

--- a/src/native/jsonschema/Ppx_deriving_jsonschema_runtime_classify.ml
+++ b/src/native/jsonschema/Ppx_deriving_jsonschema_runtime_classify.ml
@@ -1,0 +1,15 @@
+type t =
+  [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of t list
+  | `Assoc of (string * t) list
+  ]
+
+(* On native the schema value type [t] is already the JSON representation, so
+   classify/declassify are the identity. (On Melange they convert to/from
+   [Js.Json.t] — see ../../jsonschema/Ppx_deriving_jsonschema_runtime_classify.ml.) *)
+let classify value = value
+let declassify value = value

--- a/src/native/jsonschema/dune
+++ b/src/native/jsonschema/dune
@@ -1,0 +1,13 @@
+; Native runtime for [@@deriving jsonschema] (part of the melange-json-native package).
+; classify/declassify are native-specific (identity); the platform-neutral sources
+; are shared from the Melange runtime in ../../jsonschema via copy_files.
+(library
+ (name ppx_deriving_jsonschema_runtime)
+ (public_name melange-json-native.jsonschema)
+ (wrapped false))
+
+(copy_files
+ (files ../../jsonschema/ppx_deriving_jsonschema_runtime.ml))
+
+(copy_files
+ (files ../../jsonschema/ppx_deriving_jsonschema_runtime_primitives.{ml,mli}))

--- a/src/native/jsonschema/ppx_deriving_jsonschema_runtime.mli
+++ b/src/native/jsonschema/ppx_deriving_jsonschema_runtime.mli
@@ -1,0 +1,10 @@
+val schema_version : string
+
+type t = Ppx_deriving_jsonschema_runtime_classify.t
+
+val classify : t -> t
+val declassify : t -> t
+
+val json_schema : ?id:string -> ?title:string -> ?description:string -> ?definitions:(string * t) list -> t -> t
+
+module Primitives : module type of Ppx_deriving_jsonschema_runtime_primitives


### PR DESCRIPTION
## Summary

This PR is the start of merging ppx_deriving_jsonschema into melange-json. 
For that start, I just copied the files from ppx_deriving_jsonschema and pasted them here with a few changes.
Next steps will focus on handling shared things.

To make sure we are adding something that works with melange-json, I also created the wire.ml test where we validate the jsonschema with melange-json generated code.


Sample of an error:
```ocaml
type compact_variant = A | B | C of int
[@@deriving to_json, jsonschema] [@@compact_variants]

let compact_variant =
  case "compact_variant"
    (schema_of compact_variant_jsonschema)
    [
      `List [`String "A"]; (* Should fail here as the jsonschema expects string and not list *)
      compact_variant_to_json A;
      compact_variant_to_json B;
      compact_variant_to_json (C 3);
    ]
```

```diff
-  compact_variant: 3/3 valid
+  compact_variant: compact_variant.[0] is INVALID
+  Value: ["A"]
+  Schema validation errors were encountered.
+  
+    Underlying errors caused this.
+  
+    Best Match:
+      $: 'A' was expected
+    Best Deep Match:
+      $[0]: 'C' was expected
+  
+    2 other errors were produced. Use '--verbose' to see all errors
```