### PR TITLE
Fix the main ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
           - "4.14"
           - "5.1"
           - "5.2"
+          - "5.4"
 
     runs-on: ${{ matrix.os }}
 
@@ -40,5 +41,7 @@ jobs:
       - run: opam install . --deps-only --with-test --with-dev-setup
 
       - run: opam exec -- dune build
+
+      - run: pipx install check-jsonschema
 
       - run: opam exec -- dune runtest

--- a/dune-project
+++ b/dune-project
@@ -40,7 +40,7 @@
   (ocaml-lsp-server :with-dev-setup)
   (ocamlformat
    (and
-    (>= "0.27.0")
+    (= "0.28.1")
     :with-dev-setup))))
 
 (package

--- a/melange-json.opam
+++ b/melange-json.opam
@@ -20,7 +20,7 @@ depends: [
   "ppxlib" {>= "0.36.0"}
   "opam-check-npm-deps" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
-  "ocamlformat" {>= "0.27.0" & with-dev-setup}
+  "ocamlformat" {= "0.28.1" & with-dev-setup}
   "odoc" {with-doc}
 ]
 build: [
@@ -39,6 +39,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/melange-community/melange-json.git"
 pin-depends: [
-  [ "opam-check-npm-deps.dev" "git+https://github.com/ahrefs/opam-check-npm-deps.git#8adc5a6fa6b744c4007f5085ef0cf1347a4b5f36" ]
+  [ "opam-check-npm-deps.dev" "git+https://github.com/ahrefs/opam-check-npm-deps.git#ebecec84c6dddf91d7a40f67ca8bb280529330c3" ]
 ]
 

--- a/melange-json.opam.template
+++ b/melange-json.opam.template
@@ -1,4 +1,4 @@
 pin-depends: [
-  [ "opam-check-npm-deps.dev" "git+https://github.com/ahrefs/opam-check-npm-deps.git#8adc5a6fa6b744c4007f5085ef0cf1347a4b5f36" ]
+  [ "opam-check-npm-deps.dev" "git+https://github.com/ahrefs/opam-check-npm-deps.git#ebecec84c6dddf91d7a40f67ca8bb280529330c3" ]
 ]
 

--- a/ppx/jsonschema/test/wire.ml
+++ b/ppx/jsonschema/test/wire.ml
@@ -95,7 +95,6 @@ let compact_variant =
   case "compact_variant"
     (schema_of compact_variant_jsonschema)
     [
-      `List [ `String "A" ];
       compact_variant_to_json A;
       compact_variant_to_json B;
       compact_variant_to_json (C 3);


### PR DESCRIPTION
# Fix the main CI workflow

## What

Fixes the `main` GitHub Actions workflow so it builds and tests successfully again.

## Why

The `main` workflow had some breakages that caused it to fail.
First, it was deactivated because the repo was inactive. So it stopped working. As we can see here (#38), that PR was broken before I added a commit that fixed it, and on that PR (#95), I wrongly committed an [error sample](https://github.com/melange-community/melange-json/pull/97/changes#diff-3393f1a0c2ffa1629155b0eb47a5ab3673fb37dd3dd3ae20ec592ced8aeea952L98) I ran for the PR description.
Then we had an issue with dependencies under CI:

- Bump the `opam-check-npm-deps` pin.
- Update the ocaml-format as well.
