### PR TITLE
Remove the variant_as_string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- jsonschema: Remove the `~variant_as_string` flag; use
+  `[@@jsonschema.compact_variants]` to render payload-free constructors as
+  plain string constants.
 - PPX: Respect the `[@json.name "..."]` attribute in `of_json` error
   messages.
 - **[breaking]** PPX: Ignore extra JSON object fields by default in the native

--- a/JSONSCHEMA.md
+++ b/JSONSCHEMA.md
@@ -530,33 +530,37 @@ type b = [ `B of int * string * bool ] [@@deriving jsonschema ~polymorphic_varia
 }
 ```
 
-A `~variant_as_string` flag is exposed to obtain a more natural representation `"anyOf": [{ "const": "..." }, ...]`. This representation does _not_ support payloads. For example:
-
-```ocaml
-type t =
-| Typ
-| Class of string
-[@@deriving jsonschema ~variant_as_string]
-```
-
-```json
-{ "anyOf": [ { "const": "Typ" }, { "const": "Class" } ] }
-```
-
 If the JSON variant names differ from OCaml conventions, it is possible to specify the corresponding JSON string explicitly using `[@name "constr"]`, for example:
 
 ```ocaml
 type t =
 | Typ   [@name "type"]
 | Class of string [@name "class"]
-[@@deriving jsonschema ~variant_as_string]
+[@@deriving jsonschema]
 ```
 
 ```json
-{ "anyOf": [ { "const": "type" }, { "const": "class" } ] }
+{
+  "anyOf": [
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "type" } ],
+      "unevaluatedItems": false,
+      "minItems": 1,
+      "maxItems": 1
+    },
+    {
+      "type": "array",
+      "prefixItems": [ { "const": "class" }, { "type": "string" } ],
+      "unevaluatedItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  ]
+}
 ```
 
-A `[@@jsonschema.compact_variants]` attribute offers a middle ground. Unlike `~variant_as_string`, it only collapses payload-free constructors to a bare `{ "const": "..." }`; constructors with arguments keep the standard array encoding. It therefore supports payloads.
+A `[@@jsonschema.compact_variants]` attribute on the type declaration collapses payload-free constructors to a bare `{ "const": "..." }`; constructors with arguments keep the standard array encoding. It preserves the encoding of constructors with a payload.
 
 ```ocaml
 type t =

--- a/ppx/jsonschema/attrs.ml
+++ b/ppx/jsonschema/attrs.ml
@@ -1,10 +1,6 @@
 open Ppxlib
 
 type config = {
-  variant_as_string : bool;
-      (** Encode variants as string instead of string array. This option
-          breaks compatibility with yojson derivers and doesn't support
-          constructors with a payload. *)
   polymorphic_variant_tuple : bool;
       (** Preserve the implicit tuple in a polymorphic variant. This
           option breaks compatibility with yojson derivers. *)
@@ -203,7 +199,4 @@ let attributes =
 
 let args () =
   Deriving.Args.(
-    empty
-    +> flag "variant_as_string"
-    +> flag "polymorphic_variant_tuple"
-    +> flag "ocaml_doc")
+    empty +> flag "polymorphic_variant_tuple" +> flag "ocaml_doc")

--- a/ppx/jsonschema/attrs.mli
+++ b/ppx/jsonschema/attrs.mli
@@ -1,8 +1,4 @@
 type config = {
-  variant_as_string : bool;
-      (** Encode variants as string instead of string array. This option
-          breaks compatibility with yojson derivers and doesn't support
-          constructors with a payload. *)
   polymorphic_variant_tuple : bool;
       (** Preserve the implicit tuple in a polymorphic variant. This
           option breaks compatibility with yojson derivers. *)
@@ -112,4 +108,4 @@ val jsonschema_td_compact_variants :
   Ppxlib.type_declaration Ppxlib.Attribute.flag
 
 val attributes : Ppxlib.Attribute.packed list
-val args : unit -> (bool -> bool -> bool -> 'a, 'a) Ppxlib.Deriving.Args.t
+val args : unit -> (bool -> bool -> 'a, 'a) Ppxlib.Deriving.Args.t

--- a/ppx/jsonschema/ppx_deriving_jsonschema.ml
+++ b/ppx/jsonschema/ppx_deriving_jsonschema.ml
@@ -12,13 +12,11 @@ let create_value ~loc name value =
 
 (* Wraps [body] in nested lambdas, one per type parameter.
    Parametric types like [('a, 'b) t] derive as [fun a b -> <schema>],
-   so callers can pass schemas for each type variable.
-   Use [~prefix:"_"] to mark params unused in the body. *)
-let wrap_type_params ~loc ?(prefix = "") params body =
+   so callers can pass schemas for each type variable. *)
+let wrap_type_params ~loc params body =
   List.fold_right
     (fun param body ->
-      [%expr
-        fun [%p ppat_var ~loc { txt = prefix ^ param; loc }] -> [%e body]])
+      [%expr fun [%p ppat_var ~loc { txt = param; loc }] -> [%e body]])
     params body
 
 (* schema_of_core_type and schema_of_poly_variant are mutually recursive.
@@ -219,10 +217,7 @@ and schema_of_poly_variant ~loc ~(config : Attrs.config)
       ([], false) row_fields
   in
   let constrs = List.rev constrs in
-  let v =
-    Schema.variants ~loc ~as_string:config.Attrs.variant_as_string
-      ~compact_variants constrs
-  in
+  let v = Schema.variants ~loc ~compact_variants constrs in
   v, is_rec
 
 (* Returns (schema_expression, is_recursive) *)
@@ -296,7 +291,7 @@ let schema_of_record ~loc ~(config : Attrs.config) ?(recursive_types = [])
         ]],
     is_rec )
 
-(* Returns (schema_expression, is_recursive, params_prefix) *)
+(* Returns (schema_expression, is_recursive) *)
 let schema_of_variants ~loc ~(config : Attrs.config)
     ?(recursive_types = []) ?(compact_variants = false) variants =
   let variants, is_rec =
@@ -336,14 +331,10 @@ let schema_of_variants ~loc ~(config : Attrs.config)
       ([], false) variants
   in
   let variants = List.rev variants in
-  let schema, params_prefix =
-    match config.Attrs.variant_as_string with
-    | true -> Schema.variants ~loc ~as_string:true variants, "_"
-    | false -> Schema.variants ~loc ~compact_variants variants, ""
-  in
-  schema, is_rec, params_prefix
+  let schema = Schema.variants ~loc ~compact_variants variants in
+  schema, is_rec
 
-(* Returns (type_name, schema_expression, is_recursive, params, params_prefix) *)
+(* Returns (type_name, schema_expression, is_recursive, params) *)
 let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types
     type_decl =
   let type_name = type_decl.ptype_name.txt in
@@ -361,17 +352,17 @@ let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types
       let compact_variants =
         Attribute.has_flag Attrs.jsonschema_td_compact_variants type_decl
       in
-      let schema, is_rec, params_prefix =
+      let schema, is_rec =
         schema_of_variants ~loc ~config ~recursive_types ~compact_variants
           variants
       in
-      type_name, schema, is_rec, params, params_prefix
+      type_name, schema, is_rec, params
   | Ptype_record label_declarations ->
       let schema, is_rec =
         schema_of_record ~loc ~config ~recursive_types label_declarations
           allow_extra_fields
       in
-      type_name, schema, is_rec, params, ""
+      type_name, schema, is_rec, params
   | Ptype_abstract -> (
       match type_decl.ptype_manifest with
       | Some core_type ->
@@ -383,7 +374,7 @@ let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types
             schema_of_core_type ~config ~recursive_types ~compact_variants
               core_type
           in
-          type_name, schema, is_rec, params, ""
+          type_name, schema, is_rec, params
       | None ->
           let msg =
             "ppx_deriving_jsonschema: abstract type without manifest"
@@ -391,15 +382,13 @@ let schema_of_type_decl ~loc ~(config : Attrs.config) ~recursive_types
           ( type_name,
             [%expr [%ocaml.error [%e estring ~loc msg]]],
             false,
-            params,
-            "" ))
+            params ))
   | Ptype_open ->
       let msg = "ppx_deriving_jsonschema: open types not supported" in
       ( type_name,
         [%expr [%ocaml.error [%e estring ~loc msg]]],
         false,
-        params,
-        "" )
+        params )
 
 let apply_defs ~loc = function
   | `Rec (primary, defs) ->
@@ -442,12 +431,11 @@ let apply_defs ~loc = function
                        ppx_pairs)
             | other -> other)]
 
-let str_type_decl ~ctxt ast flag_variant_as_string
-    flag_polymorphic_variant_tuple flag_ocaml_doc =
+let str_type_decl ~ctxt ast flag_polymorphic_variant_tuple flag_ocaml_doc
+    =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   let config : Attrs.config =
     {
-      Attrs.variant_as_string = flag_variant_as_string;
       Attrs.polymorphic_variant_tuple = flag_polymorphic_variant_tuple;
       Attrs.ocaml_doc = flag_ocaml_doc;
     }
@@ -461,7 +449,7 @@ let str_type_decl ~ctxt ast flag_variant_as_string
         | Recursive -> [ type_name ]
         | Nonrecursive -> []
       in
-      let _, raw_schema, is_rec, params, params_prefix =
+      let _, raw_schema, is_rec, params =
         schema_of_type_decl ~loc ~config ~recursive_types type_decl
       in
       let raw_schema =
@@ -498,9 +486,7 @@ let str_type_decl ~ctxt ast flag_variant_as_string
             let ppx_eds = ref [] in
             [%e apply_defs ~loc (`NonRec raw_schema)]]
       in
-      let schema =
-        wrap_type_params ~loc ~prefix:params_prefix params schema
-      in
+      let schema = wrap_type_params ~loc params schema in
       [ create_value ~loc type_name schema ]
   (* Multiple type declarations (mutually recursive types) *)
   | rec_flag, type_decls when List.length type_decls > 1 ->
@@ -515,11 +501,11 @@ let str_type_decl ~ctxt ast flag_variant_as_string
           type_decls
       in
       let any_recursive =
-        List.exists (fun (_, _, is_rec, _, _) -> is_rec) raw_results
+        List.exists (fun (_, _, is_rec, _) -> is_rec) raw_results
       in
       if any_recursive then
         List.map
-          (fun (name, raw, _, params, prefix) ->
+          (fun (name, raw, _, params) ->
             let td =
               List.find (fun td -> td.ptype_name.txt = name) type_decls
             in
@@ -545,11 +531,11 @@ let str_type_decl ~ctxt ast flag_variant_as_string
             in
             let defs =
               List.map
-                (fun (n, r, _, _, _) -> n, if n = name then raw else r)
+                (fun (n, r, _, _) -> n, if n = name then raw else r)
                 raw_results
             in
             let schema =
-              wrap_type_params ~loc ~prefix params
+              wrap_type_params ~loc params
                 [%expr
                   let ppx_eds = ref [] in
                   [%e apply_defs ~loc (`Rec (name, defs))]]
@@ -558,12 +544,12 @@ let str_type_decl ~ctxt ast flag_variant_as_string
           raw_results
       else
         List.map
-          (fun (name, raw, _, params, prefix) ->
+          (fun (name, raw, _, params) ->
             let td =
               List.find (fun td -> td.ptype_name.txt = name) type_decls
             in
             let schema =
-              wrap_type_params ~loc ~prefix params
+              wrap_type_params ~loc params
                 [%expr
                   let ppx_eds = ref [] in
                   [%e apply_defs ~loc (`NonRec raw)]]
@@ -579,8 +565,8 @@ let str_type_decl ~ctxt ast flag_variant_as_string
   | _, _ ->
       [%str [%ocaml.error "ppx_deriving_jsonschema: unsupported type"]]
 
-let sig_type_decl ~ctxt ast _flag_variant_as_string
-    _flag_polymorphic_variant_tuple _flag_ocaml_doc =
+let sig_type_decl ~ctxt ast _flag_polymorphic_variant_tuple
+    _flag_ocaml_doc =
   let jsonschema_t ~loc =
     ptyp_constr ~loc
       { txt = Ldot (Lident "Ppx_deriving_jsonschema_runtime", "t"); loc }

--- a/ppx/jsonschema/schema.ml
+++ b/ppx/jsonschema/schema.ml
@@ -68,8 +68,7 @@ let description ~loc description schema_expr =
     ("description", [%expr `String [%e estring ~loc description]])
     schema_expr
 
-let variants ~loc ?(as_string = false) ?(compact_variants = false) constrs
-    =
+let variants ~loc ?(compact_variants = false) constrs =
   let opt_description ~loc desc schema =
     match desc with Some d -> description ~loc d schema | None -> schema
   in
@@ -78,8 +77,7 @@ let variants ~loc ?(as_string = false) ?(compact_variants = false) constrs
        (function
          | `Tag (name, typs, desc) ->
              let schema =
-               if as_string then const ~loc name
-               else if compact_variants && typs = [] then const ~loc name
+               if compact_variants && typs = [] then const ~loc name
                else tuple ~loc (const ~loc name :: typs)
              in
              opt_description ~loc desc schema

--- a/ppx/jsonschema/schema.mli
+++ b/ppx/jsonschema/schema.mli
@@ -51,7 +51,6 @@ val description :
 
 val variants :
   loc:Warnings.loc ->
-  ?as_string:bool ->
   ?compact_variants:bool ->
   [< `Inherit of Ppxlib.expression
   | `Tag of string * Ppxlib.expression list * string option ]

--- a/ppx/jsonschema/test/shared/cases.ml
+++ b/ppx/jsonschema/test/shared/cases.ml
@@ -19,29 +19,15 @@ type with_modules = { m : Mod1.m_1; m2 : Mod1.Mod2.m_2 }
 type kind = Success | Error | Skipped [@name "skipped"]
 [@@deriving jsonschema]
 
-type kind_as_string = Success | Error | Skipped [@name "skipped"]
-[@@deriving jsonschema ~variant_as_string]
-
 type poly_kind = [ `Aaa | `Bbb | `Ccc [@name "ccc"] ]
 [@@deriving jsonschema]
-
-type poly_kind_as_string = [ `Aaa | `Bbb | `Ccc [@name "ccc"] ]
-[@@deriving jsonschema ~variant_as_string]
 
 type poly_kind_with_payload =
   [ `Aaa of int | `Bbb | `Ccc of string * bool [@name "ccc"] ]
 [@@deriving jsonschema]
 
-type poly_kind_with_payload_as_string =
-  [ `Aaa of int | `Bbb | `Ccc of string * bool [@name "ccc"] ]
-[@@deriving jsonschema ~variant_as_string]
-
 type poly_inherit = [ `New_one | `Second_one of int | poly_kind ]
 [@@deriving jsonschema]
-
-type poly_inherit_as_string =
-  [ `New_one | `Second_one of int | poly_kind_as_string ]
-[@@deriving jsonschema ~variant_as_string]
 
 type event = {
   date : float;
@@ -105,9 +91,6 @@ type numbers = int list [@@deriving jsonschema]
 type opt = int option [@@deriving jsonschema]
 type using_m = { m : Mod1.m_1 } [@@deriving jsonschema]
 
-type 'param2 poly2 = C of 'param2
-[@@deriving jsonschema ~variant_as_string]
-
 type tuple_with_variant = int * [ `A | `B [@name "second_cstr"] ]
 [@@deriving jsonschema]
 
@@ -140,26 +123,13 @@ type tt = {
 
 type c = char [@@deriving jsonschema]
 
-type variant_inline_record = A of { a : int } | B of { b : string }
-[@@deriving jsonschema ~variant_as_string]
-
 type inline_record_with_extra_fields =
   | User of { name : string; email : string }
       [@jsonschema.allow_extra_fields]
   | Guest of { ip : string }
 [@@deriving jsonschema]
 
-type variant_with_payload =
-  | A of int
-  | B
-  | C of int * string
-  | D of (int * string * bool)
-[@@deriving jsonschema ~variant_as_string]
-
 type t1 = Typ | Class of string [@@deriving jsonschema]
-
-type t2 = Typ | Class of string
-[@@deriving jsonschema ~variant_as_string]
 
 type t3 = Typ [@name "type"] | Class of string [@name "class"]
 [@@deriving jsonschema]
@@ -204,9 +174,6 @@ type 'a param_list = 'a list [@@deriving jsonschema]
 type ('a, 'b) either = Left of 'a | Right of 'b [@@deriving jsonschema]
 type ('a, 'b) either_alias = ('a, 'b) either [@@deriving jsonschema]
 
-type ('a, 'b) direction = North | South
-[@@deriving jsonschema ~variant_as_string]
-
 type tool_params = {
   query : string; [@jsonschema.description "The search query to execute"]
   max_results : int;
@@ -240,11 +207,6 @@ type described_variant =
 type described_variant_inline_record =
   | Point of { x : int; y : int } [@jsonschema.description "A 2D point"]
 [@@deriving jsonschema]
-
-type described_variant_string =
-  | A [@jsonschema.description "First choice"]
-  | B [@jsonschema.description "Second choice"]
-[@@deriving jsonschema ~variant_as_string]
 
 (* The [~ocaml_doc] flag opts into using [(** ... *)] doc comments as a
    fallback for [@jsonschema.description]. Without the flag, doc comments are

--- a/ppx/jsonschema/test/shared/generate_schemas_cases.ml
+++ b/ppx/jsonschema/test/shared/generate_schemas_cases.ml
@@ -10,17 +10,10 @@ let schemas =
     Ppx_deriving_jsonschema_runtime.json_schema Mod1.Mod2.m_2_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema with_modules_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema kind_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema kind_as_string_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema poly_kind_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
-      poly_kind_as_string_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema
       poly_kind_with_payload_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema
-      poly_kind_with_payload_as_string_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema poly_inherit_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema
-      poly_inherit_as_string_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema event_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
       recursive_record_jsonschema;
@@ -46,8 +39,6 @@ let schemas =
     Ppx_deriving_jsonschema_runtime.json_schema opt_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema using_m_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
-      (poly2_jsonschema int_jsonschema);
-    Ppx_deriving_jsonschema_runtime.json_schema
       tuple_with_variant_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
       ~id:"https://ahrefs.com/schemas/player_scores"
@@ -61,13 +52,8 @@ let schemas =
       tt_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema c_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
-      variant_inline_record_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema
       inline_record_with_extra_fields_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema
-      variant_with_payload_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema t1_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema t2_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema t3_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema t4_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema t5_jsonschema;
@@ -93,8 +79,6 @@ let schemas =
       (either_jsonschema int_jsonschema string_jsonschema);
     Ppx_deriving_jsonschema_runtime.json_schema
       (either_alias_jsonschema int_jsonschema string_jsonschema);
-    Ppx_deriving_jsonschema_runtime.json_schema
-      (direction_jsonschema int_jsonschema string_jsonschema);
     Ppx_deriving_jsonschema_runtime.json_schema tool_params_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
       described_record_jsonschema;
@@ -104,8 +88,6 @@ let schemas =
       described_variant_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
       described_variant_inline_record_jsonschema;
-    Ppx_deriving_jsonschema_runtime.json_schema
-      described_variant_string_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema
       doc_comment_record_jsonschema;
     Ppx_deriving_jsonschema_runtime.json_schema

--- a/ppx/jsonschema/test/test.expected.ml
+++ b/ppx/jsonschema/test/test.expected.ml
@@ -169,32 +169,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type kind_as_string =
-  | Success 
-  | Error 
-  | Skipped [@name "skipped"][@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let kind_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Success"))];
-                `Assoc [("const", (`String "Error"))];
-                `Assoc [("const", (`String "skipped"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type poly_kind = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving jsonschema]
 include
   struct
@@ -225,31 +199,6 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 1));
                   ("maxItems", (`Int 1))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type poly_kind_as_string = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving
-                                                                  jsonschema
-                                                                    ~variant_as_string]
-include
-  struct
-    let poly_kind_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Aaa"))];
-                `Assoc [("const", (`String "Bbb"))];
-                `Assoc [("const", (`String "ccc"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -308,32 +257,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type poly_kind_with_payload_as_string =
-  [ `Aaa of int  | `Bbb  | `Ccc of (string * bool) [@name "ccc"]][@@deriving
-                                                                   jsonschema
-                                                                    ~variant_as_string]
-include
-  struct
-    let poly_kind_with_payload_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Aaa"))];
-                `Assoc [("const", (`String "Bbb"))];
-                `Assoc [("const", (`String "ccc"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type poly_inherit = [ `New_one  | `Second_one of int  | poly_kind][@@deriving
                                                                     jsonschema]
 include
@@ -362,40 +285,7 @@ include
                   ("maxItems", (`Int 2))];
                 (match poly_kind_jsonschema with
                  | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://shared/cases.ml:39"))
-                       ::
-                       (Stdlib.List.filter
-                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                          pairs))
-                 | other -> other)]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type poly_inherit_as_string =
-  [ `New_one  | `Second_one of int  | poly_kind_as_string][@@deriving
-                                                            jsonschema
-                                                              ~variant_as_string]
-include
-  struct
-    let poly_inherit_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "New_one"))];
-                `Assoc [("const", (`String "Second_one"))];
-                (match poly_kind_as_string_jsonschema with
-                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://shared/cases.ml:43"))
+                     `Assoc (("$id", (`String "file://shared/cases.ml:29"))
                        ::
                        (Stdlib.List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
@@ -472,7 +362,7 @@ include
                ("kind_f",
                  ((match kind_jsonschema with
                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://shared/cases.ml:48"))
+                       `Assoc (("$id", (`String "file://shared/cases.ml:34"))
                          ::
                          (Stdlib.List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
@@ -1125,7 +1015,7 @@ include
       let ppx_result =
         match tree_jsonschema with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://shared/cases.ml:97")) ::
+            `Assoc (("$id", (`String "file://shared/cases.ml:83")) ::
               (Stdlib.List.filter
                  (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
         | other -> other in
@@ -1149,7 +1039,7 @@ include
         list_jsonschema
           (match event_jsonschema with
            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-               `Assoc (("$id", (`String "file://shared/cases.ml:98")) ::
+               `Assoc (("$id", (`String "file://shared/cases.ml:84")) ::
                  (Stdlib.List.filter
                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
            | other -> other) in
@@ -1174,7 +1064,7 @@ include
           (list_jsonschema
              (match event_jsonschema with
               | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:99")) ::
+                  `Assoc (("$id", (`String "file://shared/cases.ml:85")) ::
                     (Stdlib.List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -1202,7 +1092,7 @@ include
             (`List
                [(match event_jsonschema with
                  | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://shared/cases.ml:100"))
+                     `Assoc (("$id", (`String "file://shared/cases.ml:86"))
                        ::
                        (Stdlib.List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
@@ -1232,7 +1122,7 @@ include
         list_jsonschema
           (match event_comment_jsonschema with
            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-               `Assoc (("$id", (`String "file://shared/cases.ml:101")) ::
+               `Assoc (("$id", (`String "file://shared/cases.ml:87")) ::
                  (Stdlib.List.filter
                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
            | other -> other) in
@@ -1262,7 +1152,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:102")) ::
+                          (("$id", (`String "file://shared/cases.ml:88")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -1291,7 +1181,7 @@ include
         array_jsonschema
           (match events_jsonschema with
            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-               `Assoc (("$id", (`String "file://shared/cases.ml:103")) ::
+               `Assoc (("$id", (`String "file://shared/cases.ml:89")) ::
                  (Stdlib.List.filter
                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
            | other -> other) in
@@ -1356,32 +1246,13 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:106")) ::
+                          (("$id", (`String "file://shared/cases.ml:92")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
                     | other -> other)))]));
           ("required", (`List [`String "m"]));
           ("additionalProperties", (`Bool false))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type 'param2 poly2 =
-  | C of 'param2 [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let poly2_jsonschema _param2 =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc [("anyOf", (`List [`Assoc [("const", (`String "C"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1515,7 +1386,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:127")) ::
+                          (("$id", (`String "file://shared/cases.ml:110")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -1604,32 +1475,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type variant_inline_record =
-  | A of {
-  a: int } 
-  | B of {
-  b: string } [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let variant_inline_record_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "A"))];
-                `Assoc [("const", (`String "B"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type inline_record_with_extra_fields =
   | User of {
   name: string ;
@@ -1685,34 +1530,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type variant_with_payload =
-  | A of int 
-  | B 
-  | C of int * string 
-  | D of (int * string * bool) [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let variant_with_payload_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "A"))];
-                `Assoc [("const", (`String "B"))];
-                `Assoc [("const", (`String "C"))];
-                `Assoc [("const", (`String "D"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type t1 =
   | Typ 
   | Class of string [@@deriving jsonschema]
@@ -1740,30 +1557,6 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type t2 =
-  | Typ 
-  | Class of string [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let t2_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Typ"))];
-                `Assoc [("const", (`String "Class"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2127,7 +1920,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:181")) ::
+                          (("$id", (`String "file://shared/cases.ml:151")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -2161,7 +1954,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:183")) ::
+                          (("$id", (`String "file://shared/cases.ml:153")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -2262,7 +2055,7 @@ include
       let ppx_result =
         match generic_link_traffic_jsonschema string_jsonschema with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://shared/cases.ml:195")) ::
+            `Assoc (("$id", (`String "file://shared/cases.ml:165")) ::
               (Stdlib.List.filter
                  (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
         | other -> other in
@@ -2402,34 +2195,10 @@ include
       let ppx_result =
         match either_jsonschema a b with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://shared/cases.ml:205")) ::
+            `Assoc (("$id", (`String "file://shared/cases.ml:175")) ::
               (Stdlib.List.filter
                  (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
         | other -> other in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type ('a, 'b) direction =
-  | North 
-  | South [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let direction_jsonschema _a _b =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "North"))];
-                `Assoc [("const", (`String "South"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2659,36 +2428,6 @@ include
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type described_variant_string =
-  | A [@jsonschema.description "First choice"]
-  | B [@jsonschema.description "Second choice"][@@deriving
-                                                 jsonschema
-                                                   ~variant_as_string]
-include
-  struct
-    let described_variant_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc
-                   [("description", (`String "First choice"));
-                   ("const", (`String "A"))];
-                `Assoc
-                  [("description", (`String "Second choice"));
-                  ("const", (`String "B"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3185,7 +2924,7 @@ include
                       | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                           ->
                           `Assoc
-                            (("$id", (`String "file://shared/cases.ml:345"))
+                            (("$id", (`String "file://shared/cases.ml:307"))
                             ::
                             (Stdlib.List.filter
                                (fun (k, _) ->
@@ -3398,7 +3137,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:372")) ::
+                          (("$id", (`String "file://shared/cases.ml:334")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -3407,7 +3146,7 @@ include
                  ((match self_ref_jsonschema with
                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
                        `Assoc
-                         (("$id", (`String "file://shared/cases.ml:372")) ::
+                         (("$id", (`String "file://shared/cases.ml:334")) ::
                          (Stdlib.List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -3481,7 +3220,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:381"))
+                                  (`String "file://shared/cases.ml:343"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4108,7 +3847,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:469"))
+                                   (`String "file://shared/cases.ml:431"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4148,7 +3887,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:466"))
+                                  (`String "file://shared/cases.ml:428"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4168,7 +3907,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:465"))
+                                  (`String "file://shared/cases.ml:427"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4321,7 +4060,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:478"))
+                                   (`String "file://shared/cases.ml:440"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4408,7 +4147,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:496"))
+                                   (`String "file://shared/cases.ml:458"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4711,7 +4450,7 @@ module Generated_code_must_qualify_stdlib =
           let ppx_result =
             match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                `Assoc (("$id", (`String "file://shared/cases.ml:540")) ::
+                `Assoc (("$id", (`String "file://shared/cases.ml:502")) ::
                   (Stdlib.List.filter
                      (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
             | other -> other in
@@ -4775,7 +4514,7 @@ module Nonrec_type_alias =
               let ppx_result =
                 match foo_jsonschema with
                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                    `Assoc (("$id", (`String "file://shared/cases.ml:548"))
+                    `Assoc (("$id", (`String "file://shared/cases.ml:510"))
                       ::
                       (Stdlib.List.filter
                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))

--- a/ppx/jsonschema/test/test.melange.expected.ml
+++ b/ppx/jsonschema/test/test.melange.expected.ml
@@ -169,32 +169,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type kind_as_string =
-  | Success 
-  | Error 
-  | Skipped [@name "skipped"][@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let kind_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Success"))];
-                `Assoc [("const", (`String "Error"))];
-                `Assoc [("const", (`String "skipped"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type poly_kind = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving jsonschema]
 include
   struct
@@ -225,31 +199,6 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 1));
                   ("maxItems", (`Int 1))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type poly_kind_as_string = [ `Aaa  | `Bbb  | `Ccc [@name "ccc"]][@@deriving
-                                                                  jsonschema
-                                                                    ~variant_as_string]
-include
-  struct
-    let poly_kind_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Aaa"))];
-                `Assoc [("const", (`String "Bbb"))];
-                `Assoc [("const", (`String "ccc"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -308,32 +257,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type poly_kind_with_payload_as_string =
-  [ `Aaa of int  | `Bbb  | `Ccc of (string * bool) [@name "ccc"]][@@deriving
-                                                                   jsonschema
-                                                                    ~variant_as_string]
-include
-  struct
-    let poly_kind_with_payload_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Aaa"))];
-                `Assoc [("const", (`String "Bbb"))];
-                `Assoc [("const", (`String "ccc"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type poly_inherit = [ `New_one  | `Second_one of int  | poly_kind][@@deriving
                                                                     jsonschema]
 include
@@ -362,40 +285,7 @@ include
                   ("maxItems", (`Int 2))];
                 (match poly_kind_jsonschema with
                  | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://shared/cases.ml:39"))
-                       ::
-                       (Stdlib.List.filter
-                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))
-                          pairs))
-                 | other -> other)]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type poly_inherit_as_string =
-  [ `New_one  | `Second_one of int  | poly_kind_as_string][@@deriving
-                                                            jsonschema
-                                                              ~variant_as_string]
-include
-  struct
-    let poly_inherit_as_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "New_one"))];
-                `Assoc [("const", (`String "Second_one"))];
-                (match poly_kind_as_string_jsonschema with
-                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://shared/cases.ml:43"))
+                     `Assoc (("$id", (`String "file://shared/cases.ml:29"))
                        ::
                        (Stdlib.List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
@@ -472,7 +362,7 @@ include
                ("kind_f",
                  ((match kind_jsonschema with
                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                       `Assoc (("$id", (`String "file://shared/cases.ml:48"))
+                       `Assoc (("$id", (`String "file://shared/cases.ml:34"))
                          ::
                          (Stdlib.List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
@@ -1125,7 +1015,7 @@ include
       let ppx_result =
         match tree_jsonschema with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://shared/cases.ml:97")) ::
+            `Assoc (("$id", (`String "file://shared/cases.ml:83")) ::
               (Stdlib.List.filter
                  (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
         | other -> other in
@@ -1149,7 +1039,7 @@ include
         list_jsonschema
           (match event_jsonschema with
            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-               `Assoc (("$id", (`String "file://shared/cases.ml:98")) ::
+               `Assoc (("$id", (`String "file://shared/cases.ml:84")) ::
                  (Stdlib.List.filter
                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
            | other -> other) in
@@ -1174,7 +1064,7 @@ include
           (list_jsonschema
              (match event_jsonschema with
               | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                  `Assoc (("$id", (`String "file://shared/cases.ml:99")) ::
+                  `Assoc (("$id", (`String "file://shared/cases.ml:85")) ::
                     (Stdlib.List.filter
                        (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                        pairs))
@@ -1202,7 +1092,7 @@ include
             (`List
                [(match event_jsonschema with
                  | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                     `Assoc (("$id", (`String "file://shared/cases.ml:100"))
+                     `Assoc (("$id", (`String "file://shared/cases.ml:86"))
                        ::
                        (Stdlib.List.filter
                           (fun (k, _) -> not (Stdlib.String.equal k "$id"))
@@ -1232,7 +1122,7 @@ include
         list_jsonschema
           (match event_comment_jsonschema with
            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-               `Assoc (("$id", (`String "file://shared/cases.ml:101")) ::
+               `Assoc (("$id", (`String "file://shared/cases.ml:87")) ::
                  (Stdlib.List.filter
                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
            | other -> other) in
@@ -1262,7 +1152,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:102")) ::
+                          (("$id", (`String "file://shared/cases.ml:88")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -1291,7 +1181,7 @@ include
         array_jsonschema
           (match events_jsonschema with
            | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-               `Assoc (("$id", (`String "file://shared/cases.ml:103")) ::
+               `Assoc (("$id", (`String "file://shared/cases.ml:89")) ::
                  (Stdlib.List.filter
                     (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
            | other -> other) in
@@ -1356,32 +1246,13 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:106")) ::
+                          (("$id", (`String "file://shared/cases.ml:92")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
                     | other -> other)))]));
           ("required", (`List [`String "m"]));
           ("additionalProperties", (`Bool false))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type 'param2 poly2 =
-  | C of 'param2 [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let poly2_jsonschema _param2 =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc [("anyOf", (`List [`Assoc [("const", (`String "C"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -1515,7 +1386,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:127")) ::
+                          (("$id", (`String "file://shared/cases.ml:110")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -1604,32 +1475,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type variant_inline_record =
-  | A of {
-  a: int } 
-  | B of {
-  b: string } [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let variant_inline_record_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "A"))];
-                `Assoc [("const", (`String "B"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type inline_record_with_extra_fields =
   | User of {
   name: string ;
@@ -1685,34 +1530,6 @@ include
                     ppx_pairs))
            | other -> other)[@@warning "-32-39"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type variant_with_payload =
-  | A of int 
-  | B 
-  | C of int * string 
-  | D of (int * string * bool) [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let variant_with_payload_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "A"))];
-                `Assoc [("const", (`String "B"))];
-                `Assoc [("const", (`String "C"))];
-                `Assoc [("const", (`String "D"))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type t1 =
   | Typ 
   | Class of string [@@deriving jsonschema]
@@ -1740,30 +1557,6 @@ include
                   ("unevaluatedItems", (`Bool false));
                   ("minItems", (`Int 2));
                   ("maxItems", (`Int 2))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type t2 =
-  | Typ 
-  | Class of string [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let t2_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "Typ"))];
-                `Assoc [("const", (`String "Class"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2127,7 +1920,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:181")) ::
+                          (("$id", (`String "file://shared/cases.ml:151")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -2161,7 +1954,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:183")) ::
+                          (("$id", (`String "file://shared/cases.ml:153")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -2262,7 +2055,7 @@ include
       let ppx_result =
         match generic_link_traffic_jsonschema string_jsonschema with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://shared/cases.ml:195")) ::
+            `Assoc (("$id", (`String "file://shared/cases.ml:165")) ::
               (Stdlib.List.filter
                  (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
         | other -> other in
@@ -2402,34 +2195,10 @@ include
       let ppx_result =
         match either_jsonschema a b with
         | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-            `Assoc (("$id", (`String "file://shared/cases.ml:205")) ::
+            `Assoc (("$id", (`String "file://shared/cases.ml:175")) ::
               (Stdlib.List.filter
                  (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
         | other -> other in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type ('a, 'b) direction =
-  | North 
-  | South [@@deriving jsonschema ~variant_as_string]
-include
-  struct
-    let direction_jsonschema _a _b =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc [("const", (`String "North"))];
-                `Assoc [("const", (`String "South"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -2659,36 +2428,6 @@ include
                    ("unevaluatedItems", (`Bool false));
                    ("minItems", (`Int 2));
                    ("maxItems", (`Int 2))]]))] in
-      match !ppx_eds with
-      | [] -> ppx_result
-      | ppx_defs ->
-          (match ppx_result with
-           | `Assoc ppx_pairs ->
-               `Assoc (("$defs", (`Assoc ppx_defs)) ::
-                 (Stdlib.List.filter
-                    (fun (k, _) -> not (Stdlib.String.equal k "$defs"))
-                    ppx_pairs))
-           | other -> other)[@@warning "-32-39"]
-  end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type described_variant_string =
-  | A [@jsonschema.description "First choice"]
-  | B [@jsonschema.description "Second choice"][@@deriving
-                                                 jsonschema
-                                                   ~variant_as_string]
-include
-  struct
-    let described_variant_string_jsonschema =
-      let ppx_eds = ref [] in
-      let ppx_result =
-        `Assoc
-          [("anyOf",
-             (`List
-                [`Assoc
-                   [("description", (`String "First choice"));
-                   ("const", (`String "A"))];
-                `Assoc
-                  [("description", (`String "Second choice"));
-                  ("const", (`String "B"))]]))] in
       match !ppx_eds with
       | [] -> ppx_result
       | ppx_defs ->
@@ -3185,7 +2924,7 @@ include
                       | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                           ->
                           `Assoc
-                            (("$id", (`String "file://shared/cases.ml:345"))
+                            (("$id", (`String "file://shared/cases.ml:307"))
                             ::
                             (Stdlib.List.filter
                                (fun (k, _) ->
@@ -3398,7 +3137,7 @@ include
                     | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs
                         ->
                         `Assoc
-                          (("$id", (`String "file://shared/cases.ml:372")) ::
+                          (("$id", (`String "file://shared/cases.ml:334")) ::
                           (Stdlib.List.filter
                              (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                              pairs))
@@ -3407,7 +3146,7 @@ include
                  ((match self_ref_jsonschema with
                    | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
                        `Assoc
-                         (("$id", (`String "file://shared/cases.ml:372")) ::
+                         (("$id", (`String "file://shared/cases.ml:334")) ::
                          (Stdlib.List.filter
                             (fun (k, _) -> not (Stdlib.String.equal k "$id"))
                             pairs))
@@ -3481,7 +3220,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:381"))
+                                  (`String "file://shared/cases.ml:343"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4124,7 +3863,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:469"))
+                                   (`String "file://shared/cases.ml:431"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4164,7 +3903,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:466"))
+                                  (`String "file://shared/cases.ml:428"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4184,7 +3923,7 @@ include
                              Stdlib.List.mem_assoc "$defs" pairs ->
                              `Assoc
                                (("$id",
-                                  (`String "file://shared/cases.ml:465"))
+                                  (`String "file://shared/cases.ml:427"))
                                ::
                                (Stdlib.List.filter
                                   (fun (k, _) ->
@@ -4340,7 +4079,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:478"))
+                                   (`String "file://shared/cases.ml:440"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4434,7 +4173,7 @@ include
                               Stdlib.List.mem_assoc "$defs" pairs ->
                               `Assoc
                                 (("$id",
-                                   (`String "file://shared/cases.ml:496"))
+                                   (`String "file://shared/cases.ml:458"))
                                 ::
                                 (Stdlib.List.filter
                                    (fun (k, _) ->
@@ -4737,7 +4476,7 @@ module Generated_code_must_qualify_stdlib =
           let ppx_result =
             match wrapper_with_shadowed_stdlib_jsonschema int_jsonschema with
             | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                `Assoc (("$id", (`String "file://shared/cases.ml:540")) ::
+                `Assoc (("$id", (`String "file://shared/cases.ml:502")) ::
                   (Stdlib.List.filter
                      (fun (k, _) -> not (Stdlib.String.equal k "$id")) pairs))
             | other -> other in
@@ -4801,7 +4540,7 @@ module Nonrec_type_alias =
               let ppx_result =
                 match foo_jsonschema with
                 | `Assoc pairs when Stdlib.List.mem_assoc "$defs" pairs ->
-                    `Assoc (("$id", (`String "file://shared/cases.ml:548"))
+                    `Assoc (("$id", (`String "file://shared/cases.ml:510"))
                       ::
                       (Stdlib.List.filter
                          (fun (k, _) -> not (Stdlib.String.equal k "$id"))

--- a/ppx/jsonschema/test/test_schemas.expected.json
+++ b/ppx/jsonschema/test/test_schemas.expected.json
@@ -112,12 +112,6 @@
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "anyOf": [
-        { "const": "Success" }, { "const": "Error" }, { "const": "skipped" }
-      ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [
         {
           "type": "array",
           "prefixItems": [ { "const": "Aaa" } ],
@@ -140,10 +134,6 @@
           "maxItems": 1
         }
       ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "const": "Aaa" }, { "const": "Bbb" }, { "const": "ccc" } ]
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -172,10 +162,6 @@
           "maxItems": 3
         }
       ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "const": "Aaa" }, { "const": "Bbb" }, { "const": "ccc" } ]
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -217,18 +203,6 @@
               "minItems": 1,
               "maxItems": 1
             }
-          ]
-        }
-      ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [
-        { "const": "New_one" },
-        { "const": "Second_one" },
-        {
-          "anyOf": [
-            { "const": "Aaa" }, { "const": "Bbb" }, { "const": "ccc" }
           ]
         }
       ]
@@ -616,7 +590,7 @@
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$id": "file://ppx/jsonschema/test/cases.ml:97",
+      "$id": "file://ppx/jsonschema/test/cases.ml:83",
       "$defs": {
         "tree": {
           "anyOf": [
@@ -1162,10 +1136,6 @@
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "const": "C" } ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "array",
       "prefixItems": [
         { "type": "integer" },
@@ -1266,10 +1236,6 @@
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "const": "A" }, { "const": "B" } ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "anyOf": [
         {
           "type": "array",
@@ -1309,15 +1275,6 @@
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "anyOf": [
-        { "const": "A" },
-        { "const": "B" },
-        { "const": "C" },
-        { "const": "D" }
-      ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [
         {
           "type": "array",
           "prefixItems": [ { "const": "Typ" } ],
@@ -1333,10 +1290,6 @@
           "maxItems": 2
         }
       ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "const": "Typ" }, { "const": "Class" } ]
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1641,10 +1594,6 @@
     },
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [ { "const": "North" }, { "const": "South" } ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
         "max_results": {
@@ -1748,13 +1697,6 @@
           "minItems": 2,
           "maxItems": 2
         }
-      ]
-    },
-    {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "anyOf": [
-        { "description": "First choice", "const": "A" },
-        { "description": "Second choice", "const": "B" }
       ]
     },
     {
@@ -2021,7 +1963,7 @@
       "type": "object",
       "properties": {
         "b": {
-          "$id": "file://ppx/jsonschema/test/cases.ml:372",
+          "$id": "file://ppx/jsonschema/test/cases.ml:334",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2038,7 +1980,7 @@
           "$ref": "#/$defs/self_ref"
         },
         "a": {
-          "$id": "file://ppx/jsonschema/test/cases.ml:372",
+          "$id": "file://ppx/jsonschema/test/cases.ml:334",
           "$defs": {
             "self_ref": {
               "type": "object",
@@ -2144,7 +2086,7 @@
               "prefixItems": [
                 { "const": "BoolAtom" },
                 {
-                  "$id": "file://ppx/jsonschema/test/cases.ml:381",
+                  "$id": "file://ppx/jsonschema/test/cases.ml:343",
                   "$defs": {
                     "filter": {
                       "anyOf": [


### PR DESCRIPTION
`~variant_as_string` rendered every constructor as a bare string constant (`{ "const": "Name" }`), silently dropping any payload. `[@@jsonschema.compact_variants]` already covers the genuinely useful case — payload-free constructors as plain string constants, while payload-carrying constructors keep their array encoding. The two only produced identical output for all-nullary variants; on payload-carrying constructors `variant_as_string`'s behavior is a footgun (the schema no longer validates the actual data). The flag is therefore redundant and removed.


## Original [PR](https://github.com/ahrefs/ppx_deriving_jsonschema/pull/53)