### PR TITLE
Add the no-misplaced-attrs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,11 @@
 ## Unreleased
 
-
-- **[breaking]** change the name of the project from `melange-json` to `jsonkit` to reflect the fact that it is now a general-purpose JSON library, not
-  tied to Melange/Native. The PPX is now in a separate package `ppx_deriving_jsonkit`. ([#107](https://github.com/melange-community/melange-json/pull/107))
-- **[breaking]** swap the package names so the native build takes the plain
-  name: `jsonkit-native` is now `jsonkit`, and the Melange package is now
-  `jsonkit-melange`. Sub-libraries move with them (`jsonkit-native.ppx` →
-  `jsonkit.ppx`, `jsonkit.ppx` → `jsonkit-melange.ppx`, likewise for
-  `.jsonschema`). The exposed module is still `Jsonkit` on both backends, so
-  only `dune` and `opam` references need updating.
+- PPX: Creates a linter to warn about the wrong usage of [@json.name] on record fields
+  and [@json.key] on variant constructors.
+- PPX: Adds a linter that catches namespaced melange-json field attributes
+  (`[@json.name]`, `[@json.key]`, `[@json.default]`, etc.) on
+  `[@@deriving json, jsonschema]` types, to use `[@name]`,
+  `[@key]`, `[@default]`, `[@option]` instead.
 - jsonschema: Remove the `~variant_as_string` flag; use
   `[@@jsonschema.compact_variants]` to render payload-free constructors as
   plain string constants.

--- a/ppx/native/common/linter.ml
+++ b/ppx/native/common/linter.ml
@@ -133,8 +133,136 @@ module No_qualified_shared_attrs = struct
     end
 end
 
+module No_misplaced_attrs = struct
+  type ctx = Td | Ld | Cd | Rtag | Ct
+
+  let shared_attributes = function
+    | "key" | "option" | "default" -> Some [ Ld ]
+    | "name" -> Some [ Cd; Rtag ]
+    | "allow_extra_fields" | "disallow_extra_fields" -> Some [ Td; Cd ]
+    | "compact_variants" -> Some [ Td ]
+    | _ -> None
+
+  let json_attributes = function
+    | "allow_any" | "catch_all" -> Some [ Cd; Rtag ]
+    | "drop_default" | "drop_default_if_json_equal" -> Some [ Ld ]
+    | name -> shared_attributes name
+
+  let jsonschema_attributes = function
+    | "ref" -> Some [ Ld ]
+    | "description" -> Some [ Td; Ld; Cd; Rtag; Ct ]
+    | "format" | "minimum" | "maximum" | "attrs" -> Some [ Td; Ld; Ct ]
+    | name -> shared_attributes name
+
+  let allowed_contexts ~json ~jsonschema name =
+    let contexts_of requested contexts name =
+      if requested then contexts name else None
+    in
+    match String.index_opt name '.' with
+    | Some i -> (
+        let base = String.sub name (i + 1) (String.length name - i - 1) in
+        match String.sub name 0 i with
+        | "json" -> contexts_of json json_attributes base
+        | "jsonschema" ->
+            contexts_of jsonschema jsonschema_attributes base
+        | _ -> None)
+    | None -> (
+        match
+          ( contexts_of json json_attributes name,
+            contexts_of jsonschema jsonschema_attributes name )
+        with
+        | Some a, Some b -> Some (a @ b)
+        | (Some _ as x), None | None, (Some _ as x) -> x
+        | None, None -> None)
+
+  let current_ctx = function
+    | Td -> "a type declaration"
+    | Ld -> "a record field"
+    | Cd -> "a variant constructor"
+    | Rtag -> "a polymorphic variant tag"
+    | Ct -> "a type expression"
+
+  let allowed_ctx = function
+    | Td -> "type declarations"
+    | Ld -> "record fields"
+    | Cd -> "variant constructors"
+    | Rtag -> "polymorphic variant tags"
+    | Ct -> "type expressions"
+
+  let check_attrs ~json ~jsonschema ~ctx acc (attrs : attributes) =
+    if not (json || jsonschema) then acc
+    else
+      List.fold_left
+        (fun acc (attr : attribute) ->
+          let name = attr.attr_name.txt in
+          match allowed_contexts ~json ~jsonschema name with
+          | Some allowed when not (List.mem ctx allowed) ->
+              lint_errorf ~loc:attr.attr_loc
+                "melange-json linter: [@%s] is not allowed on %s; it \
+                 applies to %s"
+                name (current_ctx ctx)
+                (String.concat ", "
+                   (List.map allowed_ctx (List.sort_uniq compare allowed)))
+              :: acc
+          | _ -> acc)
+        acc attrs
+
+  let rule =
+    object (self)
+      inherit [Driver.Lint_error.t list] Ast_traverse.fold as super
+      val mutable derives_json = false
+      val mutable derives_jsonschema = false
+
+      method private flag_derivers tds =
+        derives_json <- group_derives_json tds;
+        derives_jsonschema <- group_derives_jsonschema tds
+
+      method private unflag_derivers =
+        derives_json <- false;
+        derives_jsonschema <- false
+
+      method! structure_item item acc =
+        match item.pstr_desc with
+        | Pstr_type (_, tds) ->
+            self#flag_derivers tds;
+            let acc = super#structure_item item acc in
+            self#unflag_derivers;
+            acc
+        | _ -> super#structure_item item acc
+
+      method! signature_item item acc =
+        match item.psig_desc with
+        | Psig_type (_, tds) ->
+            self#flag_derivers tds;
+            let acc = super#signature_item item acc in
+            self#unflag_derivers;
+            acc
+        | _ -> super#signature_item item acc
+
+      method private check ctx attrs acc =
+        check_attrs ~json:derives_json ~jsonschema:derives_jsonschema ~ctx
+          acc attrs
+
+      method! type_declaration td acc =
+        self#check Td td.ptype_attributes (super#type_declaration td acc)
+
+      method! label_declaration ld acc =
+        self#check Ld ld.pld_attributes (super#label_declaration ld acc)
+
+      method! constructor_declaration cd acc =
+        self#check Cd cd.pcd_attributes
+          (super#constructor_declaration cd acc)
+
+      method! row_field rf acc =
+        self#check Rtag rf.prf_attributes (super#row_field rf acc)
+
+      method! core_type ct acc =
+        self#check Ct ct.ptyp_attributes (super#core_type ct acc)
+    end
+end
+
 let rules : Driver.Lint_error.t list Ast_traverse.fold list =
-  [ No_qualified_shared_attrs.rule ]
+  [ No_qualified_shared_attrs.rule; No_misplaced_attrs.rule ]
 
 let lint_impl (structure : structure) : Driver.Lint_error.t list =
   List.rev

--- a/ppx/test/linter.t
+++ b/ppx/test/linter.t
@@ -88,3 +88,23 @@ group, not just the one carrying the attribute.
   $ ../native/ppx_deriving_json_native_test.exe input.ml --use-compiler-pp 2>&1 | grep "melange-json linter"
     "melange-json linter: [@json.key] only applies to the json deriver, but this type derives both json and jsonschema; use the unqualified [@key] so it applies to both"]
     "melange-json linter: [@jsonschema.name] only applies to the jsonschema deriver, but this type derives both json and jsonschema; use the unqualified [@name] so it applies to both"]
+
+Deriver attributes used in a context they do not apply to are flagged,
+whether qualified or not. Attributes are only matched against the
+deriver(s) the type actually uses, so [@jsonschema.format] is ignored when
+only [json] is derived.
+
+  $ cat > input.ml <<'EOF'
+  > type t = { foo : int [@json.name "a"] [@jsonschema.format "int32"] }
+  > [@@deriving json]
+  > 
+  > type u = A [@key "k"] [@json.drop_default]
+  > [@@deriving json, jsonschema] [@@json.default 1]
+  > 
+  > EOF
+
+  $ ../native/ppx_deriving_json_native_test.exe input.ml --use-compiler-pp 2>&1 | grep "melange-json linter"
+    "melange-json linter: [@json.name] is not allowed on a record field; it applies to variant constructors, polymorphic variant tags"]
+    "melange-json linter: [@key] is not allowed on a variant constructor; it applies to record fields"]
+    "melange-json linter: [@json.drop_default] is not allowed on a variant constructor; it applies to record fields"]
+    "melange-json linter: [@json.default] is not allowed on a type declaration; it applies to record fields"]


### PR DESCRIPTION
## Summary

Creates a linter to warn about the wrong usage of [@json.name] on record fields

```ocaml
(* BAD: [@name] is ignored, the field serializes as "to_" *)
type params = { to_ : date [@name "to"] } [@@deriving json]

(* GOOD *)
type params = { to_ : date [@key "to"] } [@@deriving json]
```